### PR TITLE
Adapt QFR to new DD Package

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,82 +1,82 @@
 # Generated from CLion C/C++ Code Style settings
-BasedOnStyle: LLVM
-AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: true
-AlignEscapedNewlines: Left
-AlignOperands: AlignAfterOperator
-AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
+BasedOnStyle:                              LLVM
+AccessModifierOffset:                      -4
+AlignAfterOpenBracket:                     Align
+AlignConsecutiveAssignments:               Consecutive
+AlignConsecutiveDeclarations:              Consecutive
+AlignEscapedNewlines:                      Left
+AlignOperands:                             AlignAfterOperator
+AlignTrailingComments:                     true
+AllowAllArgumentsOnNextLine:               true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: Empty
-AllowShortCaseLabelsOnASingleLine: true
-AllowShortEnumsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: WithoutElse
-AllowShortLambdasOnASingleLine: All
-AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterReturnType: None
-AlwaysBreakTemplateDeclarations: Yes
-BreakBeforeBraces: Custom
+AllowShortBlocksOnASingleLine:             Empty
+AllowShortCaseLabelsOnASingleLine:         true
+AllowShortEnumsOnASingleLine:              true
+AllowShortFunctionsOnASingleLine:          Inline
+AllowShortIfStatementsOnASingleLine:       WithoutElse
+AllowShortLambdasOnASingleLine:            All
+AllowShortLoopsOnASingleLine:              true
+AlwaysBreakAfterReturnType:                None
+AlwaysBreakTemplateDeclarations:           Yes
+BreakBeforeBraces:                         Custom
 BraceWrapping:
-  AfterCaseLabel: false
-  AfterClass: false
+  AfterCaseLabel:        false
+  AfterClass:            false
   AfterControlStatement: Never
-  AfterEnum: false
-  AfterFunction: false
-  AfterNamespace: false
-  AfterUnion: false
-  BeforeCatch: false
-  BeforeElse: false
-  IndentBraces: false
-  SplitEmptyFunction: false
-  SplitEmptyRecord: false
-BreakBeforeBinaryOperators: None
-BreakBeforeTernaryOperators: false
-BreakConstructorInitializers: AfterColon
-BreakInheritanceList: AfterColon
-ColumnLimit: 0
-CompactNamespaces: false
-ContinuationIndentWidth: 8
-Cpp11BracedListStyle: true
-DeriveLineEnding: true
-#EmptyLineBeforeAccessModifier: LogicalBlock
-IncludeBlocks: Regroup
-IndentCaseBlocks: false
-IndentCaseLabels: true
-IndentPPDirectives: BeforeHash
-IndentWidth: 4
-KeepEmptyLinesAtTheStartOfBlocks: false
-Language: Cpp
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: All
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
-PointerAlignment: Left
-ReflowComments: false
-SortIncludes: true
-SpaceAfterCStyleCast: false
-SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: false
-SpaceBeforeAssignmentOperators: true
-#SpaceBeforeCaseColon: false
-SpaceBeforeCpp11BracedList: false
-SpaceBeforeCtorInitializerColon: false
-SpaceBeforeInheritanceColon: false
-SpaceBeforeParens: ControlStatements
-SpaceBeforeRangeBasedForLoopColon: false
-SpaceBeforeSquareBrackets: false
-SpaceInEmptyBlock: false
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
-SpacesInConditionalStatement: false
-SpacesInCStyleCastParentheses: false
-SpacesInContainerLiterals: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard: c++17
-TabWidth: 4
-UseTab: Never
+  AfterEnum:             false
+  AfterFunction:         false
+  AfterNamespace:        false
+  AfterUnion:            false
+  BeforeCatch:           false
+  BeforeElse:            false
+  IndentBraces:          false
+  SplitEmptyFunction:    false
+  SplitEmptyRecord:      false
+BreakBeforeBinaryOperators:                None
+BreakBeforeTernaryOperators:               false
+BreakConstructorInitializers:              AfterColon
+BreakInheritanceList:                      AfterColon
+ColumnLimit:                               0
+CompactNamespaces:                         false
+ContinuationIndentWidth:                   8
+Cpp11BracedListStyle:                      true
+DeriveLineEnding:                          true
+EmptyLineBeforeAccessModifier:             LogicalBlock
+IncludeBlocks:                             Regroup
+IndentCaseBlocks:                          false
+IndentCaseLabels:                          true
+IndentPPDirectives:                        BeforeHash
+IndentWidth:                               4
+KeepEmptyLinesAtTheStartOfBlocks:          false
+Language:                                  Cpp
+MaxEmptyLinesToKeep:                       1
+NamespaceIndentation:                      All
+ObjCSpaceAfterProperty:                    false
+ObjCSpaceBeforeProtocolList:               true
+PointerAlignment:                          Left
+ReflowComments:                            false
+SortIncludes:                              true
+SpaceAfterCStyleCast:                      false
+SpaceAfterLogicalNot:                      false
+SpaceAfterTemplateKeyword:                 false
+SpaceBeforeAssignmentOperators:            true
+SpaceBeforeCaseColon:                      false
+SpaceBeforeCpp11BracedList:                false
+SpaceBeforeCtorInitializerColon:           false
+SpaceBeforeInheritanceColon:               false
+SpaceBeforeParens:                         ControlStatements
+SpaceBeforeRangeBasedForLoopColon:         false
+SpaceBeforeSquareBrackets:                 false
+SpaceInEmptyBlock:                         false
+SpaceInEmptyParentheses:                   false
+SpacesBeforeTrailingComments:              1
+SpacesInAngles:                            false
+SpacesInConditionalStatement:              false
+SpacesInCStyleCastParentheses:             false
+SpacesInContainerLiterals:                 false
+SpacesInParentheses:                       false
+SpacesInSquareBrackets:                    false
+Standard:                                  c++17
+TabWidth:                                  4
+UseTab:                                    Never

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,5 +2,12 @@ ignore:
   - "extern/**/*"
 
 coverage:
-  range: 60..90
+  range:     60..90
   precision: 1
+  status:
+    project:
+      default:
+        threshold: 0.5%
+    patch:
+      default:
+        threshold: 1%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
         run:   |
                if [ "$RUNNER_OS" == "Windows" ]; then
                  cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -T "ClangCl" -DBUILD_QFR_TESTS=ON
-               elif [ "$RUNNER_OS" == "macOS" ]; then
-                 cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QFR_TESTS=ON -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
                else
                  cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QFR_TESTS=ON
                fi
@@ -61,8 +59,6 @@ jobs:
         run:   |
                if [ "$RUNNER_OS" == "Windows" ]; then
                  cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -T "ClangCl" -DBUILD_QFR_TESTS=ON
-               elif [ "$RUNNER_OS" == "macOS" ]; then
-                 cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QFR_TESTS=ON -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
                else
                  cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QFR_TESTS=ON
                fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,11 @@ jobs:
           python-version: '3.8'
       - name:  Configure CMake
         shell: bash
-        run:   cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Release -DCOVERAGE=1 -DBUILD_QFR_TESTS=ON
+        run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=1 -DBUILD_QFR_TESTS=ON
 
       - name:  Build
         shell: bash
-        run:   cmake --build "${{github.workspace}}/build" --config Release --target qfr_test
+        run: cmake --build "${{github.workspace}}/build" --config Debug --target qfr_test
 
       - name:              Test
         working-directory: ${{github.workspace}}/build/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: DoozyX/clang-format-lint-action@v0.11
+      - uses: DoozyX/clang-format-lint-action@v0.12
         with:
-          source: 'include src test jkq/qfr'
-          extensions: 'h,hpp,c,cpp'
-          clangFormatVersion: 11
+          source:             'include src test jkq/qfr'
+          extensions:         'h,hpp,c,cpp'
+          clangFormatVersion: 12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,11 @@ jobs:
         python-version: '3.8'
     - name: Configure CMake
       shell: bash
-      run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=1 -DBUILD_QFR_TESTS=ON
+      run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Release -DCOVERAGE=1 -DBUILD_QFR_TESTS=ON
 
     - name: Build
       shell: bash
-      run: cmake --build "${{github.workspace}}/build" --config Debug --target qfr_test
+      run: cmake --build "${{github.workspace}}/build" --config Release --target qfr_test
 
     - name: Test
       working-directory: ${{github.workspace}}/build/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: CI
 
-on: 
+on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
   workflow_dispatch:
 
 env:
@@ -16,97 +16,101 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Configure CMake
-      shell: bash
-      run: |
-         if [ "$RUNNER_OS" == "Windows" ]; then
-           cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -T "ClangCl" -DBUILD_QFR_TESTS=ON
-         else
-           cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QFR_TESTS=ON
-         fi  
-        
-    - name: Build
-      shell: bash
-      run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name:  Configure CMake
+        shell: bash
+        run:   |
+               if [ "$RUNNER_OS" == "Windows" ]; then
+                 cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -T "ClangCl" -DBUILD_QFR_TESTS=ON
+               elif [ "$RUNNER_OS" == "macOS" ]; then
+                 cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QFR_TESTS=ON -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+               else
+                 cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QFR_TESTS=ON
+               fi
+
+      - name:  Build
+        shell: bash
+        run:   cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
 
   test:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Configure CMake
-      shell: bash
-      run: |
-         if [ "$RUNNER_OS" == "Windows" ]; then
-           cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -T "ClangCl" -DBUILD_QFR_TESTS=ON
-         else
-           cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QFR_TESTS=ON
-         fi  
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name:  Configure CMake
+        shell: bash
+        run:   |
+               if [ "$RUNNER_OS" == "Windows" ]; then
+                 cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -T "ClangCl" -DBUILD_QFR_TESTS=ON
+               elif [ "$RUNNER_OS" == "macOS" ]; then
+                 cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QFR_TESTS=ON -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+               else
+                 cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QFR_TESTS=ON
+               fi
 
-    - name: Build
-      shell: bash
-      run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qfr_test
+      - name:  Build
+        shell: bash
+        run:   cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qfr_test
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build/test
-      shell: bash
-      run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          cd $BUILD_TYPE
-          ./qfr_test.exe
-        else
-          ./qfr_test
-        fi
-    
+      - name:              Test
+        working-directory: ${{github.workspace}}/build/test
+        shell:             bash
+        run:               |
+                           if [ "$RUNNER_OS" == "Windows" ]; then
+                             cd $BUILD_TYPE
+                             ./qfr_test.exe
+                           else
+                             ./qfr_test
+                           fi
+
   coverage:
     needs: test
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Configure CMake
-      shell: bash
-      run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Release -DCOVERAGE=1 -DBUILD_QFR_TESTS=ON
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name:  Configure CMake
+        shell: bash
+        run:   cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Release -DCOVERAGE=1 -DBUILD_QFR_TESTS=ON
 
-    - name: Build
-      shell: bash
-      run: cmake --build "${{github.workspace}}/build" --config Release --target qfr_test
+      - name:  Build
+        shell: bash
+        run:   cmake --build "${{github.workspace}}/build" --config Release --target qfr_test
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build/test
-      shell: bash
-      run: ./qfr_test
-        
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true
+      - name:              Test
+        working-directory: ${{github.workspace}}/build/test
+        shell:             bash
+        run:               ./qfr_test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
 
   codestyle:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ env:
   CIBW_BUILD_VERBOSITY: 3
   CIBW_TEST_COMMAND: "python -c \"from jkq import qfr\""
   CIBW_BEFORE_BUILD: "pip install cmake"
-  CIBW_ENVIRONMENT_MACOS: "CC='gcc-10' CXX='g++-10'"
 
 jobs:
   build_wheels:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ env:
   CIBW_BUILD_VERBOSITY: 3
   CIBW_TEST_COMMAND: "python -c \"from jkq import qfr\""
   CIBW_BEFORE_BUILD: "pip install cmake"
+  CIBW_ENVIRONMENT_MACOS: "CC='gcc-10' CXX='g++-10'"
 
 jobs:
   build_wheels:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "extern/dd_package"]
 	path = extern/dd_package
 	url = https://github.com/iic-jku/dd_package.git
-	branch = master
+	branch = new_package_fixes
 [submodule "extern/json"]
 	path = extern/json
 	url = https://github.com/nlohmann/json.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "extern/dd_package"]
 	path = extern/dd_package
 	url = https://github.com/iic-jku/dd_package.git
-	branch = new_package_fixes
+	branch = master
 [submodule "extern/json"]
 	path = extern/json
 	url = https://github.com/nlohmann/json.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14...3.19)
 
 project(qfr
         LANGUAGES CXX
-        VERSION 1.3.0
+        VERSION 1.4.0
         DESCRIPTION "QFR  - A JKQ library for Quantum Functionality Representation"
         )
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ It acts as an intermediate representation and provides the facilitites to
 Building (and running) is continuously tested under Linux, MacOS, and Windows using the [latest available system versions for GitHub Actions](https://github.com/actions/virtual-environments). However, the implementation should be compatible
 with any current C++ compiler supporting C++17 and a minimum CMake version of 3.14.
 
-Note that using (Apple)Clang to compile the library under macOS might lead to severe performance degradation. Consider using gcc to compile the project!
-
 It is recommended (although not required) to have [GraphViz](https://www.graphviz.org) installed for visualization purposes.
 
 ### Configure, Build, and Install

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ It acts as an intermediate representation and provides the facilitites to
   std::string filename = "PATH_TO_DESTINATION_FILE.qasm";
   qc.dump(filename);
   ```
-  
+
   Currently available file formats are:
     * `OpenQASM` (.qasm)
 
@@ -125,18 +125,23 @@ It acts as an intermediate representation and provides the facilitites to
 
 ### System Requirements
 
-Building (and running) is continuously tested under Linux, MacOS, and Windows using the [latest available system versions for GitHub Actions](https://github.com/actions/virtual-environments).
-However, the implementation should be compatible with any current C++ compiler supporting C++17 and a minimum CMake version of 3.14.
+Building (and running) is continuously tested under Linux, MacOS, and Windows using the [latest available system versions for GitHub Actions](https://github.com/actions/virtual-environments). However, the implementation should be compatible
+with any current C++ compiler supporting C++17 and a minimum CMake version of 3.14.
+
+Note that using (Apple)Clang to compile the library under macOS might lead to severe performance degradation. Consider using gcc to compile the project!
 
 It is recommended (although not required) to have [GraphViz](https://www.graphviz.org) installed for visualization purposes.
 
 ### Configure, Build, and Install
 
 To start off, clone this repository using
+
 ```shell
 git clone --recurse-submodules -j8 https://github.com/iic-jku/qfr 
 ```
-Note the `--recurse-submodules` flag. It is required to also clone all the required submodules. If you happen to forget passing the flag on your initial clone, you can initialize all the submodules by executing `git submodule update --init --recursive` in the main project directory.
+
+Note the `--recurse-submodules` flag. It is required to also clone all the required submodules. If you happen to forget passing the flag on your initial clone, you can initialize all the submodules by
+executing `git submodule update --init --recursive` in the main project directory.
 
 Our projects use CMake as the main build configuration tool. Building a project using CMake is a two-stage process. First, CMake needs to be *configured* by calling
 ```shell 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -5,11 +5,7 @@ add_executable(${PROJECT_NAME}_app ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp)
 target_link_libraries(${PROJECT_NAME}_app PRIVATE ${PROJECT_NAME})
 
 # enable interprocedural optimization if it is supported
-include(CheckIPOSupported)
-check_ipo_supported(RESULT ipo_supported)
-if (ipo_supported)
-	set_target_properties(${PROJECT_NAME}_app PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
-endif ()
+enable_lto(${PROJECT_NAME}_app)
 
 # create symlinks
 add_custom_command(TARGET ${PROJECT_NAME}_app

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -4,6 +4,13 @@ add_executable(${PROJECT_NAME}_app ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp)
 # link against main project library
 target_link_libraries(${PROJECT_NAME}_app PRIVATE ${PROJECT_NAME})
 
+# enable interprocedural optimization if it is supported
+include(CheckIPOSupported)
+check_ipo_supported(RESULT ipo_supported)
+if (ipo_supported)
+	set_target_properties(${PROJECT_NAME}_app PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif ()
+
 # create symlinks
 add_custom_command(TARGET ${PROJECT_NAME}_app
                    POST_BUILD

--- a/include/CircuitOptimizer.hpp
+++ b/include/CircuitOptimizer.hpp
@@ -6,16 +6,15 @@
 #ifndef QFR_CIRCUITOPTIMIZER_HPP
 #define QFR_CIRCUITOPTIMIZER_HPP
 
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+#include "dd/Package.hpp"
+#include "operations/Operation.hpp"
 
-#include <forward_list>
-#include <map>
+#include <array>
+#include <memory>
 
 namespace qc {
-    using DAG          = std::vector<std::forward_list<std::unique_ptr<Operation>*>>;
-    using DAGIterator  = std::forward_list<std::unique_ptr<Operation>*>::iterator;
-    using DAGIterators = std::vector<DAGIterator>;
-
     static constexpr std::array<qc::OpType, 8> diagonalGates = {qc::I, qc::Z, qc::S, qc::Sdag, qc::T, qc::Tdag, qc::Phase, qc::RZ};
 
     class CircuitOptimizer {
@@ -35,17 +34,17 @@ namespace qc {
 
         static void removeDiagonalGatesBeforeMeasure(QuantumComputation& qc);
 
-        static void removeDiagonalGatesBeforeMeasureRecursive(DAG& dag, DAGIterators& dagIterators, unsigned short idx, const DAGIterator& until);
+        static void removeDiagonalGatesBeforeMeasureRecursive(DAG& dag, DAGIterators& dagIterators, dd::Qubit idx, const DAGIterator& until);
 
-        static bool removeDiagonalGate(DAG& dag, DAGIterators& dagIterators, unsigned short idx, DAGIterator& it, qc::Operation* op);
+        static bool removeDiagonalGate(DAG& dag, DAGIterators& dagIterators, dd::Qubit idx, DAGIterator& it, qc::Operation* op);
 
-        static void removeMarkedMeasurments(QuantumComputation& qc);
+        static void removeMarkedMeasurements(QuantumComputation& qc);
 
         static void removeFinalMeasurements(QuantumComputation& qc);
 
-        static void removeFinalMeasurementsRecursive(DAG& dag, DAGIterators& DAGIterators, unsigned short idx, const DAGIterator& until);
+        static void removeFinalMeasurementsRecursive(DAG& dag, DAGIterators& DAGIterators, dd::Qubit idx, const DAGIterator& until);
 
-        static bool removeFinalMeasurement(DAG& dag, DAGIterators& dagIterators, unsigned short idx, DAGIterator& it, qc::Operation* op);
+        static bool removeFinalMeasurement(DAG& dag, DAGIterators& dagIterators, dd::Qubit idx, DAGIterator& it, qc::Operation* op);
 
         static void decomposeSWAP(QuantumComputation& qc, bool isDirectedArchitecture);
 

--- a/include/Definitions.hpp
+++ b/include/Definitions.hpp
@@ -59,6 +59,8 @@ namespace qc {
         }
     };
 
+    constexpr dd::fp PARAMETER_TOLERANCE = 10e-6;
+
     // forward declaration
     class Operation;
 

--- a/include/Definitions.hpp
+++ b/include/Definitions.hpp
@@ -20,7 +20,7 @@ namespace qc {
 
     public:
         explicit QFRException(std::string msg):
-                std::invalid_argument("QFR Exception"), msg(std::move(msg)) {}
+            std::invalid_argument("QFR Exception"), msg(std::move(msg)) {}
 
         [[nodiscard]] const char* what() const noexcept override {
             return msg.c_str();
@@ -35,12 +35,12 @@ namespace qc {
     using RegisterMap          = std::map<std::string, RegisterType, std::greater<>>;
     using QuantumRegisterMap   = RegisterMap<QuantumRegister>;
     using ClassicalRegisterMap = RegisterMap<ClassicalRegister>;
-    using RegisterNames = std::vector<std::pair<std::string, std::string>>;
+    using RegisterNames        = std::vector<std::pair<std::string, std::string>>;
 
     using VectorDD = dd::Package::vEdge;
     using MatrixDD = dd::Package::mEdge;
 
-    using Targets  = std::vector<dd::Qubit>;
+    using Targets = std::vector<dd::Qubit>;
 
     struct Permutation: public std::map<dd::Qubit, dd::Qubit> {
         [[nodiscard]] inline dd::Controls apply(const dd::Controls& controls) const {

--- a/include/Definitions.hpp
+++ b/include/Definitions.hpp
@@ -1,0 +1,80 @@
+/*
+ * This file is part of JKQ QFR library which is released under the MIT license.
+ * See file README.md or go to http://iic.jku.at/eda/research/quantum/ for more information.
+ */
+
+#ifndef QFR_DEFINITIONS_HPP
+#define QFR_DEFINITIONS_HPP
+
+#include "dd/Package.hpp"
+
+#include <forward_list>
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace qc {
+    class QFRException: public std::invalid_argument {
+        std::string msg;
+
+    public:
+        explicit QFRException(std::string msg):
+                std::invalid_argument("QFR Exception"), msg(std::move(msg)) {}
+
+        [[nodiscard]] const char* what() const noexcept override {
+            return msg.c_str();
+        }
+    };
+
+    template<class IdxType, class SizeType>
+    using Register          = std::pair<IdxType, SizeType>;
+    using QuantumRegister   = Register<dd::Qubit, dd::QubitCount>;
+    using ClassicalRegister = Register<std::size_t, std::size_t>;
+    template<class RegisterType>
+    using RegisterMap          = std::map<std::string, RegisterType, std::greater<>>;
+    using QuantumRegisterMap   = RegisterMap<QuantumRegister>;
+    using ClassicalRegisterMap = RegisterMap<ClassicalRegister>;
+    using RegisterNames = std::vector<std::pair<std::string, std::string>>;
+
+    using VectorDD = dd::Package::vEdge;
+    using MatrixDD = dd::Package::mEdge;
+
+    using Targets  = std::vector<dd::Qubit>;
+
+    struct Permutation: public std::map<dd::Qubit, dd::Qubit> {
+        [[nodiscard]] inline dd::Controls apply(const dd::Controls& controls) const {
+            dd::Controls c{};
+            for (const auto& control: controls) {
+                c.emplace(dd::Control{at(control.qubit), control.type});
+            }
+            return c;
+        }
+        [[nodiscard]] inline Targets apply(const Targets& targets) const {
+            Targets t{};
+            for (const auto& target: targets) {
+                t.emplace_back(at(target));
+            }
+            return t;
+        }
+    };
+
+    // forward declaration
+    class Operation;
+
+    // supported file formats
+    enum Format {
+        Real,
+        OpenQASM,
+        GRCS,
+        Qiskit,
+        TFC,
+        QC
+    };
+
+    using DAG          = std::vector<std::forward_list<std::unique_ptr<Operation>*>>;
+    using DAGIterator  = std::forward_list<std::unique_ptr<Operation>*>::iterator;
+    using DAGIterators = std::vector<DAGIterator>;
+} // namespace qc
+
+#endif //QFR_DEFINITIONS_HPP

--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -6,6 +6,7 @@
 #ifndef QFR_QUANTUMCOMPUTATION_H
 #define QFR_QUANTUMCOMPUTATION_H
 
+#include "Definitions.hpp"
 #include "operations/ClassicControlledOperation.hpp"
 #include "operations/NonUnitaryOperation.hpp"
 #include "operations/StandardOperation.hpp"
@@ -24,13 +25,7 @@
 #include <string>
 #include <vector>
 
-#define DEBUG_MODE_QC 0
-
 namespace qc {
-    using reg            = std::pair<unsigned short, unsigned short>;
-    using registerMap    = std::map<std::string, reg, std::greater<>>;
-    using permutationMap = std::map<unsigned short, unsigned short>;
-
     static constexpr char DEFAULT_QREG[2]{"q"};
     static constexpr char DEFAULT_CREG[2]{"c"};
     static constexpr char DEFAULT_ANCREG[4]{"anc"};
@@ -43,57 +38,126 @@ namespace qc {
 
     protected:
         std::vector<std::unique_ptr<Operation>> ops{};
-        unsigned short                          nqubits      = 0;
-        unsigned short                          nclassics    = 0;
-        unsigned short                          nancillae    = 0;
-        unsigned short                          max_controls = 0;
+        dd::QubitCount                          nqubits      = 0;
+        std::size_t                             nclassics    = 0;
+        dd::QubitCount                          nancillae    = 0;
+        dd::QubitCount                          max_controls = 0;
         std::string                             name;
 
         // reg[reg_name] = {start_index, length}
-        registerMap qregs{};
-        registerMap cregs{};
-        registerMap ancregs{};
+        QuantumRegisterMap   qregs{};
+        ClassicalRegisterMap cregs{};
+        QuantumRegisterMap   ancregs{};
 
         void importOpenQASM(std::istream& is);
         void importReal(std::istream& is);
         int  readRealHeader(std::istream& is);
         void readRealGateDescriptions(std::istream& is, int line);
         void importTFC(std::istream& is);
-        int  readTFCHeader(std::istream& is, std::map<std::string, unsigned short>& varMap);
-        void readTFCGateDescriptions(std::istream& is, int line, std::map<std::string, unsigned short>& varMap);
+        int  readTFCHeader(std::istream& is, std::map<std::string, dd::Qubit>& varMap);
+        void readTFCGateDescriptions(std::istream& is, int line, std::map<std::string, dd::Qubit>& varMap);
         void importQC(std::istream& is);
-        int  readQCHeader(std::istream& is, std::map<std::string, unsigned short>& varMap);
-        void readQCGateDescriptions(std::istream& is, int line, std::map<std::string, unsigned short>& varMap);
+        int  readQCHeader(std::istream& is, std::map<std::string, dd::Qubit>& varMap);
+        void readQCGateDescriptions(std::istream& is, int line, std::map<std::string, dd::Qubit>& varMap);
         void importGRCS(std::istream& is);
 
-        static void printSortedRegisters(const registerMap& regmap, const std::string& identifier, std::ostream& of);
-        static void consolidateRegister(registerMap& regs);
+        template<class RegisterType>
+        static void printSortedRegisters(const RegisterMap<RegisterType>& regmap, const std::string& identifier, std::ostream& of) {
+            // sort regs by start index
+            std::map<decltype(RegisterType::first), std::pair<std::string, RegisterType>> sortedRegs{};
+            for (const auto& reg: regmap) {
+                sortedRegs.insert({reg.second.first, reg});
+            }
 
-        static void create_reg_array(const registerMap& regs, regnames_t& regnames, unsigned short defaultnumber, const char* defaultname);
+            for (const auto& reg: sortedRegs) {
+                of << identifier << " " << reg.second.first << "[" << static_cast<std::size_t>(reg.second.second.second) << "];" << std::endl;
+            }
+        }
+        template<class RegisterType>
+        static void consolidateRegister(RegisterMap<RegisterType>& regs) {
+            bool finished = false;
+            while (!finished) {
+                for (const auto& qreg: regs) {
+                    finished     = true;
+                    auto regname = qreg.first;
+                    // check if lower part of register
+                    if (regname.length() > 2 && regname.compare(regname.size() - 2, 2, "_l") == 0) {
+                        auto lowidx = qreg.second.first;
+                        auto lownum = qreg.second.second;
+                        // search for higher part of register
+                        auto highname = regname.substr(0, regname.size() - 1) + 'h';
+                        auto it       = regs.find(highname);
+                        if (it != regs.end()) {
+                            auto highidx = it->second.first;
+                            auto highnum = it->second.second;
+                            // fusion of registers possible
+                            if (lowidx + lownum == highidx) {
+                                finished        = false;
+                                auto targetname = regname.substr(0, regname.size() - 2);
+                                auto targetidx  = lowidx;
+                                auto targetnum  = lownum + highnum;
+                                regs.insert({targetname, {targetidx, targetnum}});
+                                regs.erase(regname);
+                                regs.erase(highname);
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
 
-        [[nodiscard]] unsigned short getSmallestAncillary() const {
-            for (size_t i = 0; i < ancillary.size(); ++i) {
-                if (ancillary.test(i))
+        template<class RegisterType>
+        static void createRegisterArray(const RegisterMap<RegisterType>& regs, RegisterNames& regnames, decltype(RegisterType::second) defaultnumber, const char* defaultname) {
+            regnames.clear();
+
+            std::stringstream ss;
+            if (!regs.empty()) {
+                // sort regs by start index
+                std::map<decltype(RegisterType::first), std::pair<std::string, RegisterType>> sortedRegs{};
+                for (const auto& reg: regs) {
+                    sortedRegs.insert({reg.second.first, reg});
+                }
+
+                for (const auto& reg: sortedRegs) {
+                    for (decltype(RegisterType::second) i = 0; i < reg.second.second.second; i++) {
+                        ss << reg.second.first << "[" << static_cast<std::size_t>(i) << "]";
+                        regnames.push_back(std::make_pair(reg.second.first, ss.str()));
+                        ss.str(std::string());
+                    }
+                }
+            } else {
+                for (decltype(RegisterType::second) i = 0; i < defaultnumber; i++) {
+                    ss << defaultname << "[" << static_cast<std::size_t>(i) << "]";
+                    regnames.push_back(std::make_pair(defaultname, ss.str()));
+                    ss.str(std::string());
+                }
+            }
+        }
+
+        [[nodiscard]] std::size_t getSmallestAncillary() const {
+            for (std::size_t i = 0; i < ancillary.size(); ++i) {
+                if (ancillary[i])
                     return i;
             }
             return ancillary.size();
         }
 
-        [[nodiscard]] unsigned short getSmallestGarbage() const {
-            for (size_t i = 0; i < garbage.size(); ++i) {
-                if (garbage.test(i))
+        [[nodiscard]] std::size_t getSmallestGarbage() const {
+            for (std::size_t i = 0; i < garbage.size(); ++i) {
+                if (garbage[i])
                     return i;
             }
             return garbage.size();
         }
-        [[nodiscard]] bool isLastOperationOnQubit(const decltype(ops.begin())& opIt) const {
+        [[nodiscard]] bool isLastOperationOnQubit(const decltype(ops.cbegin())& opIt) const {
             const auto end = ops.cend();
             return isLastOperationOnQubit(opIt, end);
         }
 
     public:
         QuantumComputation() = default;
-        explicit QuantumComputation(unsigned short nqubits) {
+        explicit QuantumComputation(std::size_t nqubits) {
             addQubitRegister(nqubits);
             addClassicalRegister(nqubits);
         }
@@ -106,55 +170,95 @@ namespace qc {
         QuantumComputation& operator=(QuantumComputation&& qc) noexcept = default;
         virtual ~QuantumComputation()                                   = default;
 
-        [[nodiscard]] virtual size_t     getNops() const { return ops.size(); }
-        [[nodiscard]] unsigned short     getNqubits() const { return nqubits + nancillae; }
-        [[nodiscard]] unsigned short     getNancillae() const { return nancillae; }
-        [[nodiscard]] unsigned short     getNqubitsWithoutAncillae() const { return nqubits; }
-        [[nodiscard]] unsigned short     getNcbits() const { return nclassics; }
-        [[nodiscard]] std::string        getName() const { return name; }
-        [[nodiscard]] const registerMap& getQregs() const { return qregs; }
-        [[nodiscard]] const registerMap& getCregs() const { return cregs; }
-        [[nodiscard]] const registerMap& getANCregs() const { return ancregs; }
+        [[nodiscard]] virtual std::size_t         getNops() const { return ops.size(); }
+        [[nodiscard]] dd::QubitCount              getNqubits() const { return nqubits + nancillae; }
+        [[nodiscard]] dd::QubitCount              getNancillae() const { return nancillae; }
+        [[nodiscard]] dd::QubitCount              getNqubitsWithoutAncillae() const { return nqubits; }
+        [[nodiscard]] std::size_t                 getNcbits() const { return nclassics; }
+        [[nodiscard]] std::string                 getName() const { return name; }
+        [[nodiscard]] const QuantumRegisterMap&   getQregs() const { return qregs; }
+        [[nodiscard]] const ClassicalRegisterMap& getCregs() const { return cregs; }
+        [[nodiscard]] const QuantumRegisterMap&   getANCregs() const { return ancregs; }
 
         // initialLayout[physical_qubit] = logical_qubit
-        permutationMap initialLayout{};
-        permutationMap outputPermutation{};
+        Permutation initialLayout{};
+        Permutation outputPermutation{};
 
-        std::bitset<MAX_QUBITS> ancillary{};
-        std::bitset<MAX_QUBITS> garbage{};
+        std::vector<bool> ancillary{};
+        std::vector<bool> garbage{};
 
-        [[nodiscard]] unsigned long long getNindividualOps() const;
+        [[nodiscard]] std::size_t getNindividualOps() const;
 
-        [[nodiscard]] std::string                            getQubitRegister(unsigned short physical_qubit_index) const;
-        [[nodiscard]] std::string                            getClassicalRegister(unsigned short classical_index) const;
-        static unsigned short                                getHighestLogicalQubitIndex(const permutationMap& map);
-        [[nodiscard]] unsigned short                         getHighestLogicalQubitIndex() const { return getHighestLogicalQubitIndex(initialLayout); };
-        [[nodiscard]] std::pair<std::string, unsigned short> getQubitRegisterAndIndex(unsigned short physical_qubit_index) const;
-        [[nodiscard]] std::pair<std::string, unsigned short> getClassicalRegisterAndIndex(unsigned short classical_index) const;
+        [[nodiscard]] std::string                         getQubitRegister(dd::Qubit physical_qubit_index) const;
+        [[nodiscard]] std::string                         getClassicalRegister(std::size_t classical_index) const;
+        static dd::Qubit                                  getHighestLogicalQubitIndex(const Permutation& map);
+        [[nodiscard]] dd::Qubit                           getHighestLogicalQubitIndex() const { return getHighestLogicalQubitIndex(initialLayout); };
+        [[nodiscard]] std::pair<std::string, dd::Qubit>   getQubitRegisterAndIndex(dd::Qubit physical_qubit_index) const;
+        [[nodiscard]] std::pair<std::string, std::size_t> getClassicalRegisterAndIndex(std::size_t classical_index) const;
 
-        [[nodiscard]] unsigned short getIndexFromQubitRegister(const std::pair<std::string, unsigned short>& qubit) const;
-        [[nodiscard]] unsigned short getIndexFromClassicalRegister(const std::pair<std::string, unsigned short>& clbit) const;
-        [[nodiscard]] bool           isIdleQubit(unsigned short physical_qubit) const;
-        static bool                  isLastOperationOnQubit(const decltype(ops.begin())& opIt, const decltype(ops.cend())& end);
-        [[nodiscard]] bool           physicalQubitIsAncillary(unsigned short physical_qubit_index) const;
-        [[nodiscard]] bool           logicalQubitIsAncillary(unsigned short logical_qubit_index) const { return ancillary.test(logical_qubit_index); }
-        void                         setLogicalQubitAncillary(unsigned short logical_qubit_index) { ancillary.set(logical_qubit_index); }
-        dd::Edge                     reduceAncillae(dd::Edge& e, std::unique_ptr<dd::Package>& dd, bool regular = true) const {
-            return dd->reduceAncillae(e, ancillary, regular);
-        }
-        [[nodiscard]] bool logicalQubitIsGarbage(unsigned short logical_qubit_index) const { return garbage.test(logical_qubit_index); }
-        void               setLogicalQubitGarbage(unsigned short logical_qubit_index) { garbage.set(logical_qubit_index); }
-        dd::Edge           reduceGarbage(dd::Edge& e, std::unique_ptr<dd::Package>& dd, bool regular = true) const {
-            return dd->reduceGarbage(e, garbage, regular);
-        }
-        dd::Edge createInitialMatrix(std::unique_ptr<dd::Package>& dd) const; // creates identity matrix, which is reduced with respect to the ancillary qubits
+        [[nodiscard]] dd::Qubit   getIndexFromQubitRegister(const std::pair<std::string, dd::Qubit>& qubit) const;
+        [[nodiscard]] std::size_t getIndexFromClassicalRegister(const std::pair<std::string, std::size_t>& clbit) const;
+        [[nodiscard]] bool        isIdleQubit(dd::Qubit physical_qubit) const;
+        [[nodiscard]] bool        isLastOperationOnQubit(const decltype(ops.cbegin())& opIt, const decltype(ops.cend())& end) const;
+        [[nodiscard]] bool        physicalQubitIsAncillary(dd::Qubit physical_qubit_index) const;
+        [[nodiscard]] bool        logicalQubitIsAncillary(dd::Qubit logical_qubit_index) const { return ancillary[logical_qubit_index]; }
+        void                      setLogicalQubitAncillary(dd::Qubit logical_qubit_index) { ancillary[logical_qubit_index] = true; }
+        [[nodiscard]] bool        logicalQubitIsGarbage(dd::Qubit logical_qubit_index) const { return garbage[logical_qubit_index]; }
+        void                      setLogicalQubitGarbage(dd::Qubit logical_qubit_index) { garbage[logical_qubit_index] = true; }
+        MatrixDD                  createInitialMatrix(std::unique_ptr<dd::Package>& dd) const; // creates identity matrix, which is reduced with respect to the ancillary qubits
 
         /// strip away qubits with no operations applied to them and which do not pop up in the output permutation
         /// \param force if true, also strip away idle qubits occurring in the output permutation
         void stripIdleQubits(bool force = false, bool reduceIOpermutations = true);
         // apply swaps 'on' DD in order to change 'from' to 'to'
         // where |from| >= |to|
-        static void changePermutation(dd::Edge& on, qc::permutationMap& from, const qc::permutationMap& to, std::array<short, qc::MAX_QUBITS>& line, std::unique_ptr<dd::Package>& dd, bool regular = true);
+        template<class DD>
+        static void changePermutation(DD& on, Permutation& from, const Permutation& to, std::unique_ptr<dd::Package>& dd, bool regular = true) {
+            assert(from.size() >= to.size());
+
+            // iterate over (k,v) pairs of second permutation
+            for (const auto& [i, goal]: to) {
+                // search for key in the first map
+                auto it = from.find(i);
+                if (it == from.end()) {
+                    throw QFRException("[changePermutation] Key " + std::to_string(it->first) + " was not found in first permutation. This should never happen.");
+                }
+                auto current = it->second;
+
+                // permutations agree for this key value
+                if (current == goal) continue;
+
+                // search for goal value in first permutation
+                dd::Qubit j = 0;
+                for (const auto& [key, value]: from) {
+                    if (value == goal) {
+                        j = key;
+                        break;
+                    }
+                }
+
+                // swap i and j
+                auto saved = on;
+                if constexpr (std::is_same_v<DD, VectorDD>) {
+                    on = dd->multiply(dd->makeSWAPDD(on.p->v+1, {}, from.at(i), from.at(j)), on);
+                } else {
+                    // the regular flag only has an effect on matrix DDs
+                    if (regular) {
+                        on = dd->multiply(dd->makeSWAPDD(on.p->v+1, {}, from.at(i), from.at(j)), on);
+                    } else {
+                        on = dd->multiply(on, dd->makeSWAPDD(on.p->v+1, {}, from.at(i), from.at(j)));
+                    }
+                }
+
+                dd->incRef(on);
+                dd->decRef(saved);
+                dd->garbageCollect();
+
+                // update permutation
+                from.at(i) = goal;
+                from.at(j) = current;
+            }
+        }
 
         void import(const std::string& filename);
         void import(const std::string& filename, Format format);
@@ -164,7 +268,7 @@ namespace qc {
         void import(std::istream&& is, Format format);
         void initializeIOMapping();
         // search for current position of target value in map and afterwards exchange it with the value at new position
-        static void findAndSWAP(unsigned short targetValue, unsigned short newPosition, permutationMap& map) {
+        static void findAndSWAP(dd::Qubit targetValue, dd::Qubit newPosition, Permutation& map) {
             for (const auto& q: map) {
                 if (q.second == targetValue) {
                     std::swap(map.at(newPosition), map.at(q.first));
@@ -174,36 +278,28 @@ namespace qc {
         }
 
         // this function augments a given circuit by additional registers
-        void addQubitRegister(unsigned short nq, const char* reg_name = DEFAULT_QREG);
-        void addClassicalRegister(unsigned short nc, const char* reg_name = DEFAULT_CREG);
-        void addAncillaryRegister(unsigned short nq, const char* reg_name = DEFAULT_ANCREG);
+        void addQubitRegister(dd::QubitCount nq, const char* reg_name = DEFAULT_QREG);
+        void addClassicalRegister(std::size_t nc, const char* reg_name = DEFAULT_CREG);
+        void addAncillaryRegister(dd::QubitCount nq, const char* reg_name = DEFAULT_ANCREG);
 
         // removes the a specific logical qubit and returns the index of the physical qubit in the initial layout
         // as well as the index of the removed physical qubit's output permutation
         // i.e., initialLayout[physical_qubit] = logical_qubit and outputPermutation[physicalQubit] = output_qubit
-        std::pair<unsigned short, short> removeQubit(unsigned short logical_qubit_index);
+        std::pair<dd::Qubit, dd::Qubit> removeQubit(dd::Qubit logical_qubit_index);
 
         // adds physical qubit as ancillary qubit and gives it the appropriate output mapping
-        void addAncillaryQubit(unsigned short physical_qubit_index, short output_qubit_index);
+        void addAncillaryQubit(dd::Qubit physical_qubit_index, dd::Qubit output_qubit_index);
         // try to add logical qubit to circuit and assign it to physical qubit with certain output permutation value
-        void addQubit(unsigned short logical_qubit_index, unsigned short physical_qubit_index, short output_qubit_index);
+        void addQubit(dd::Qubit logical_qubit_index, dd::Qubit physical_qubit_index, dd::Qubit output_qubit_index);
 
-        void updateMaxControls(unsigned short ncontrols) {
+        void updateMaxControls(dd::QubitCount ncontrols) {
             max_controls = std::max(ncontrols, max_controls);
         }
 
-        virtual dd::Edge simulate(const dd::Edge& in, std::unique_ptr<dd::Package>& dd) const;
-        virtual dd::Edge buildFunctionality(std::unique_ptr<dd::Package>& dd) const;
-        virtual dd::Edge buildFunctionalityRecursive(std::unique_ptr<dd::Package>& dd) const;
-        virtual bool     buildFunctionalityRecursive(unsigned int depth, size_t opIdx, std::stack<dd::Edge>& s, std::array<short, MAX_QUBITS>& line, permutationMap& map, std::unique_ptr<dd::Package>& dd) const;
-
-        /// Obtain vector/matrix entry for row i (and column j). Does not include common factor e.w!
-        /// \param dd package to use
-        /// \param e vector/matrix dd
-        /// \param i row index
-        /// \param j column index
-        /// \return temporary complex value representing the vector/matrix entry
-        virtual dd::Complex getEntry(std::unique_ptr<dd::Package>& dd, dd::Edge e, unsigned long long i, unsigned long long j) const;
+        virtual VectorDD simulate(const VectorDD& in, std::unique_ptr<dd::Package>& dd) const;
+        virtual MatrixDD buildFunctionality(std::unique_ptr<dd::Package>& dd) const;
+        virtual MatrixDD buildFunctionalityRecursive(std::unique_ptr<dd::Package>& dd) const;
+        virtual bool     buildFunctionalityRecursive(std::size_t depth, std::size_t opIdx, std::stack<MatrixDD>& s, Permutation& permutation, std::unique_ptr<dd::Package>& dd) const;
 
         /**
 		 * printing
@@ -212,19 +308,13 @@ namespace qc {
 
         friend std::ostream& operator<<(std::ostream& os, const QuantumComputation& qc) { return qc.print(os); }
 
-        virtual std::ostream& printMatrix(std::unique_ptr<dd::Package>& dd, dd::Edge e, std::ostream& os) const;
-
-        static void printBin(unsigned long long n, std::stringstream& ss);
-
-        virtual std::ostream& printCol(std::unique_ptr<dd::Package>& dd, dd::Edge e, unsigned long long j, std::ostream& os) const;
-
-        virtual std::ostream& printVector(std::unique_ptr<dd::Package>& dd, dd::Edge e, std::ostream& os) const;
+        static void printBin(std::size_t n, std::stringstream& ss);
 
         virtual std::ostream& printStatistics(std::ostream& os) const;
 
         std::ostream& printRegisters(std::ostream& os = std::cout) const;
 
-        static std::ostream& printPermutationMap(const permutationMap& map, std::ostream& os = std::cout);
+        static std::ostream& printPermutation(const Permutation& permutation, std::ostream& os = std::cout);
 
         virtual void dump(const std::string& filename, Format format);
         virtual void dump(const std::string& filename);

--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -240,13 +240,13 @@ namespace qc {
                 // swap i and j
                 auto saved = on;
                 if constexpr (std::is_same_v<DD, VectorDD>) {
-                    on = dd->multiply(dd->makeSWAPDD(on.p->v+1, {}, from.at(i), from.at(j)), on);
+                    on = dd->multiply(dd->makeSWAPDD(on.p->v + 1, {}, from.at(i), from.at(j)), on);
                 } else {
                     // the regular flag only has an effect on matrix DDs
                     if (regular) {
-                        on = dd->multiply(dd->makeSWAPDD(on.p->v+1, {}, from.at(i), from.at(j)), on);
+                        on = dd->multiply(dd->makeSWAPDD(on.p->v + 1, {}, from.at(i), from.at(j)), on);
                     } else {
-                        on = dd->multiply(on, dd->makeSWAPDD(on.p->v+1, {}, from.at(i), from.at(j)));
+                        on = dd->multiply(on, dd->makeSWAPDD(on.p->v + 1, {}, from.at(i), from.at(j)));
                     }
                 }
 

--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -212,8 +212,8 @@ namespace qc {
         void stripIdleQubits(bool force = false, bool reduceIOpermutations = true);
         // apply swaps 'on' DD in order to change 'from' to 'to'
         // where |from| >= |to|
-        template<class DD>
-        static void changePermutation(DD& on, Permutation& from, const Permutation& to, std::unique_ptr<dd::Package>& dd, bool regular = true) {
+        template<class DDType>
+        static void changePermutation(DDType& on, Permutation& from, const Permutation& to, std::unique_ptr<dd::Package>& dd, bool regular = true) {
             assert(from.size() >= to.size());
 
             // iterate over (k,v) pairs of second permutation
@@ -239,7 +239,7 @@ namespace qc {
 
                 // swap i and j
                 auto saved = on;
-                if constexpr (std::is_same_v<DD, VectorDD>) {
+                if constexpr (std::is_same_v<DDType, VectorDD>) {
                     on = dd->multiply(dd->makeSWAPDD(on.p->v + 1, {}, from.at(i), from.at(j)), on);
                 } else {
                     // the regular flag only has an effect on matrix DDs

--- a/include/algorithms/BernsteinVazirani.hpp
+++ b/include/algorithms/BernsteinVazirani.hpp
@@ -17,10 +17,10 @@ namespace qc {
         void full_BernsteinVazirani();
 
     public:
-        unsigned long hiddenInteger = 0;
-        unsigned int  size          = -1;
+        std::size_t    hiddenInteger = 0;
+        dd::QubitCount size          = 0;
 
-        explicit BernsteinVazirani(unsigned long hiddenInt);
+        explicit BernsteinVazirani(std::size_t hiddenInt);
 
         std::ostream& printStatistics(std::ostream& os) const override;
     };

--- a/include/algorithms/Entanglement.hpp
+++ b/include/algorithms/Entanglement.hpp
@@ -11,7 +11,7 @@
 namespace qc {
     class Entanglement: public QuantumComputation {
     public:
-        explicit Entanglement(unsigned short nq);
+        explicit Entanglement(dd::QubitCount nq);
     };
 } // namespace qc
 

--- a/include/algorithms/GoogleRandomCircuitSampling.hpp
+++ b/include/algorithms/GoogleRandomCircuitSampling.hpp
@@ -33,15 +33,15 @@ namespace qc {
 
         std::ostream& printStatistics(std::ostream& os) const override;
 
-        dd::Edge buildFunctionality(std::unique_ptr<dd::Package>& dd) const override;
-        dd::Edge buildFunctionality(std::unique_ptr<dd::Package>& dd, unsigned short ncycles) {
+        MatrixDD buildFunctionality(std::unique_ptr<dd::Package>& dd) const override;
+        MatrixDD buildFunctionality(std::unique_ptr<dd::Package>& dd, unsigned short ncycles) {
             if (ncycles < cycles.size() - 2) {
                 removeCycles(cycles.size() - 2 - ncycles);
             }
             return buildFunctionality(dd);
         }
-        dd::Edge simulate(const dd::Edge& in, std::unique_ptr<dd::Package>& dd) const override;
-        dd::Edge simulate(const dd::Edge& in, std::unique_ptr<dd::Package>& dd, unsigned short ncycles) {
+        VectorDD simulate(const VectorDD& in, std::unique_ptr<dd::Package>& dd) const override;
+        VectorDD simulate(const VectorDD& in, std::unique_ptr<dd::Package>& dd, unsigned short ncycles) {
             if (ncycles < cycles.size() - 2) {
                 removeCycles(cycles.size() - 2 - ncycles);
             }

--- a/include/algorithms/Grover.hpp
+++ b/include/algorithms/Grover.hpp
@@ -14,7 +14,7 @@
 namespace qc {
     class Grover: public QuantumComputation {
     protected:
-        std::function<unsigned long long()> oracleGenerator;
+        std::function<std::size_t()> oracleGenerator;
 
         void setup(QuantumComputation& qc) const;
 
@@ -24,19 +24,15 @@ namespace qc {
 
         void full_grover(QuantumComputation& qc) const;
 
-        std::array<short, MAX_QUBITS> line{};
-
     public:
-        unsigned int       seed       = 0;
-        unsigned long long x          = 0;
-        unsigned long long iterations = 1;
+        std::size_t seed       = 0;
+        std::size_t x          = 0;
+        std::size_t iterations = 1;
 
-        explicit Grover(unsigned short nq, unsigned int seed = 0);
+        explicit Grover(dd::QubitCount nq, std::size_t seed = 0);
 
-        dd::Edge buildFunctionality(std::unique_ptr<dd::Package>& dd) const override;
-        dd::Edge buildFunctionalityRecursive(std::unique_ptr<dd::Package>& dd) const override;
-
-        dd::Edge simulate(const dd::Edge& in, std::unique_ptr<dd::Package>& dd) const override;
+        MatrixDD buildFunctionality(std::unique_ptr<dd::Package>& dd) const override;
+        MatrixDD buildFunctionalityRecursive(std::unique_ptr<dd::Package>& dd) const override;
 
         std::ostream& printStatistics(std::ostream& os) const override;
     };

--- a/include/algorithms/QFT.hpp
+++ b/include/algorithms/QFT.hpp
@@ -11,13 +11,9 @@
 namespace qc {
     class QFT: public QuantumComputation {
     public:
-        explicit QFT(unsigned short nq);
+        explicit QFT(dd::QubitCount nq);
 
         std::ostream& printStatistics(std::ostream& os) const override;
-
-        dd::Edge buildFunctionality(std::unique_ptr<dd::Package>& dd) const override;
-
-        dd::Edge simulate(const dd::Edge& in, std::unique_ptr<dd::Package>& dd) const override;
     };
 } // namespace qc
 

--- a/include/algorithms/RandomCliffordCircuit.hpp
+++ b/include/algorithms/RandomCliffordCircuit.hpp
@@ -13,16 +13,16 @@
 namespace qc {
     class RandomCliffordCircuit: public QuantumComputation {
     protected:
-        std::function<unsigned short()> cliffordGenerator;
+        std::function<std::uint_fast16_t()> cliffordGenerator;
 
-        void append1QClifford(unsigned int idx, unsigned short target);
-        void append2QClifford(unsigned int idx, unsigned short control, unsigned short target);
+        void append1QClifford(std::uint_fast16_t idx, dd::Qubit target);
+        void append2QClifford(std::uint_fast16_t, dd::Qubit control, dd::Qubit target);
 
     public:
-        unsigned int depth = 1;
-        unsigned int seed  = 0;
+        std::size_t depth = 1;
+        std::size_t seed  = 0;
 
-        explicit RandomCliffordCircuit(unsigned short nq, unsigned int depth = 1, unsigned int seed = 0);
+        explicit RandomCliffordCircuit(dd::QubitCount nq, std::size_t depth = 1, std::size_t seed = 0);
 
         std::ostream& printStatistics(std::ostream& os) const override;
     };

--- a/include/operations/ClassicControlledOperation.hpp
+++ b/include/operations/ClassicControlledOperation.hpp
@@ -10,15 +10,22 @@
 
 namespace qc {
 
-    class ClassicControlledOperation: public Operation {
+    class ClassicControlledOperation final: public Operation {
     protected:
-        std::unique_ptr<Operation>                op;
-        std::pair<unsigned short, unsigned short> controlRegister{};
-        unsigned int                              expectedValue = 1U;
+        std::unique_ptr<Operation>           op;
+        std::pair<dd::Qubit, dd::QubitCount> controlRegister{};
+        unsigned int                         expectedValue = 1U;
+
+        MatrixDD getDD([[maybe_unused]] std::unique_ptr<dd::Package>& dd, [[maybe_unused]] const dd::Controls& controls, [[maybe_unused]] const Targets& targets) const override {
+            throw QFRException("[ClassicControlledOperation] protected getDD called which should not happen.");
+        }
+        MatrixDD getInverseDD([[maybe_unused]] std::unique_ptr<dd::Package>& dd, [[maybe_unused]] const dd::Controls& controls, [[maybe_unused]] const Targets& targets) const override {
+            throw QFRException("[ClassicControlledOperation] protected getInverseDD called which should not happen.");
+        }
 
     public:
         // Applies operation `_op` if the creg starting at index `control` has the expected value
-        ClassicControlledOperation(std::unique_ptr<Operation>& _op, const std::pair<unsigned short, unsigned short>& controlRegister, unsigned int expectedValue = 1U):
+        ClassicControlledOperation(std::unique_ptr<Operation>& _op, const std::pair<dd::Qubit, dd::QubitCount>& controlRegister, unsigned int expectedValue = 1U):
             op(std::move(_op)), controlRegister(controlRegister), expectedValue(expectedValue) {
             nqubits = op->getNqubits();
             name[0] = 'c';
@@ -30,20 +37,20 @@ namespace qc {
             type         = ClassicControlled;
         }
 
-        dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line) const override {
-            return op->getDD(dd, line);
+        MatrixDD getDD(std::unique_ptr<dd::Package>& dd) const override {
+            return op->getDD(dd);
         }
 
-        dd::Edge getInverseDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line) const override {
-            return op->getInverseDD(dd, line);
+        MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd) const override {
+            return op->getInverseDD(dd);
         }
 
-        dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, std::map<unsigned short, unsigned short>& permutation) const override {
-            return op->getDD(dd, line, permutation);
+        MatrixDD getDD(std::unique_ptr<dd::Package>& dd, Permutation& permutation) const override {
+            return op->getDD(dd, permutation);
         }
 
-        dd::Edge getInverseDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, std::map<unsigned short, unsigned short>& permutation) const override {
-            return op->getInverseDD(dd, line, permutation);
+        MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd, Permutation& permutation) const override {
+            return op->getInverseDD(dd, permutation);
         }
 
         [[nodiscard]] auto getControlRegister() const {
@@ -66,27 +73,15 @@ namespace qc {
             return true;
         }
 
-        [[nodiscard]] bool actsOn(unsigned short i) const override {
+        [[nodiscard]] bool actsOn(dd::Qubit i) const override {
             return op->actsOn(i);
         }
 
-        void setLine(std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation) const override {
-            op->setLine(line, permutation);
-        }
-
-        void resetLine(std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation) const override {
-            op->resetLine(line, permutation);
-        }
-
-        void dumpOpenQASM([[maybe_unused]] std::ostream& of, [[maybe_unused]] const regnames_t& qreg, [[maybe_unused]] const regnames_t& creg) const override {
+        void dumpOpenQASM([[maybe_unused]] std::ostream& of, [[maybe_unused]] const RegisterNames& qreg, [[maybe_unused]] const RegisterNames& creg) const override {
             throw QFRException("Dumping of classically controlled gates currently not supported for qasm");
         }
 
-        void dumpReal([[maybe_unused]] std::ostream& of) const override {
-            throw QFRException("Dumping of classically controlled gates not possible in real format");
-        }
-
-        void dumpQiskit([[maybe_unused]] std::ostream& of, [[maybe_unused]] const regnames_t& qreg, [[maybe_unused]] const regnames_t& creg, [[maybe_unused]] const char* anc_reg_name) const override {
+        void dumpQiskit([[maybe_unused]] std::ostream& of, [[maybe_unused]] const RegisterNames& qreg, [[maybe_unused]] const RegisterNames& creg, [[maybe_unused]] const char* anc_reg_name) const override {
             throw QFRException("Dumping of classically controlled gates currently not supported for qiskit");
         }
     };

--- a/include/operations/CompoundOperation.hpp
+++ b/include/operations/CompoundOperation.hpp
@@ -10,9 +10,16 @@
 
 namespace qc {
 
-    class CompoundOperation: public Operation {
+    class CompoundOperation final: public Operation {
     protected:
         std::vector<std::unique_ptr<Operation>> ops{};
+
+        MatrixDD getDD([[maybe_unused]] std::unique_ptr<dd::Package>& dd, [[maybe_unused]] const dd::Controls& controls, [[maybe_unused]] const Targets& targets) const override {
+            throw QFRException("[CompoundOperation] protected getDD called which should not happen.");
+        }
+        MatrixDD getInverseDD([[maybe_unused]] std::unique_ptr<dd::Package>& dd, [[maybe_unused]] const dd::Controls& controls, [[maybe_unused]] const Targets& targets) const override {
+            throw QFRException("[CompoundOperation] protected getInverseDD called which should not happen.");
+        }
 
     public:
         explicit CompoundOperation(unsigned short nq) {
@@ -21,29 +28,7 @@ namespace qc {
             type    = Compound;
         }
 
-        template<class T>
-        void emplace_back(std::unique_ptr<T>& op) {
-            parameter[0]++;
-            ops.emplace_back(std::move(op));
-        }
-
-        template<class T, class... Args>
-        void emplace_back(Args&&... args) {
-            parameter[0]++;
-            ops.emplace_back(std::make_unique<T>(args...));
-        }
-
-        template<class T, class... Args>
-        std::vector<std::unique_ptr<Operation>>::iterator insert(std::vector<std::unique_ptr<Operation>>::const_iterator iterator, Args&&... args) {
-            return ops.insert(iterator, std::make_unique<T>(args...));
-        }
-
-        template<class T>
-        std::vector<std::unique_ptr<Operation>>::iterator insert(std::vector<std::unique_ptr<Operation>>::const_iterator iterator, std::unique_ptr<T>& op) {
-            return ops.insert(iterator, std::move(op));
-        }
-
-        void setNqubits(unsigned short nq) override {
+        void setNqubits(dd::QubitCount nq) override {
             nqubits = nq;
             for (auto& op: ops) {
                 op->setNqubits(nq);
@@ -55,50 +40,52 @@ namespace qc {
         }
 
         [[nodiscard]] bool isNonUnitaryOperation() const override {
-            bool isNonUnitary = false;
-            for (const auto& op: ops) {
-                isNonUnitary |= op->isNonUnitaryOperation();
-            }
-            return isNonUnitary;
+            return std::any_of(ops.cbegin(), ops.cend(), [] (const auto& op) { return op->isNonUnitaryOperation(); });
         }
 
-        dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line) const override {
-            dd::Edge e = dd->makeIdent(nqubits);
+        MatrixDD getDD(std::unique_ptr<dd::Package>& dd) const override {
+            MatrixDD e = dd->makeIdent(nqubits);
             for (auto& op: ops) {
-                e = dd->multiply(op->getDD(dd, line), e);
+                e = dd->multiply(op->getDD(dd), e);
             }
             return e;
         }
 
-        dd::Edge getInverseDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line) const override {
-            dd::Edge e = dd->makeIdent(nqubits);
+        MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd) const override {
+            MatrixDD e = dd->makeIdent(nqubits);
             for (auto& op: ops) {
-                e = dd->multiply(e, op->getInverseDD(dd, line));
+                e = dd->multiply(e, op->getInverseDD(dd));
             }
             return e;
         }
 
-        dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, std::map<unsigned short, unsigned short>& permutation) const override {
-            dd::Edge e = dd->makeIdent(nqubits);
+        MatrixDD getDD(std::unique_ptr<dd::Package>& dd, Permutation& permutation) const override {
+            MatrixDD e = dd->makeIdent(nqubits);
             for (auto& op: ops) {
-                e = dd->multiply(op->getDD(dd, line, permutation), e);
+                e = dd->multiply(op->getDD(dd, permutation), e);
             }
             return e;
         }
 
-        dd::Edge getInverseDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, std::map<unsigned short, unsigned short>& permutation) const override {
-            dd::Edge e = dd->makeIdent(nqubits);
+        MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd, Permutation& permutation) const override {
+            MatrixDD e = dd->makeIdent(nqubits);
             for (auto& op: ops) {
-                e = dd->multiply(e, op->getInverseDD(dd, line, permutation));
+                e = dd->multiply(e, op->getInverseDD(dd, permutation));
             }
             return e;
         }
 
         std::ostream& print(std::ostream& os) const override {
-            return print(os, standardPermutation);
-        }
+            os << name;
+            for (const auto& op: ops) {
+                os << std::endl
+                   << "\t";
+                op->print(os);
+            }
 
-        std::ostream& print(std::ostream& os, const std::map<unsigned short, unsigned short>& permutation) const override {
+            return os;        }
+
+        std::ostream& print(std::ostream& os, const Permutation& permutation) const override {
             os << name;
             for (const auto& op: ops) {
                 os << std::endl
@@ -109,27 +96,17 @@ namespace qc {
             return os;
         }
 
-        [[nodiscard]] bool actsOn(unsigned short i) const override {
-            for (const auto& op: ops) {
-                if (op->actsOn(i))
-                    return true;
-            }
-            return false;
+        [[nodiscard]] bool actsOn(dd::Qubit i) const override {
+            return std::any_of(ops.cbegin(), ops.cend(), [&i] (const auto& op) { return op->actsOn(i);});
         }
 
-        void dumpOpenQASM(std::ostream& of, const regnames_t& qreg, const regnames_t& creg) const override {
+        void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg) const override {
             for (auto& op: ops) {
                 op->dumpOpenQASM(of, qreg, creg);
             }
         }
 
-        void dumpReal(std::ostream& of) const override {
-            for (auto& op: ops) {
-                op->dumpReal(of);
-            }
-        }
-
-        void dumpQiskit(std::ostream& of, const regnames_t& qreg, const regnames_t& creg, const char* anc_reg_name) const override {
+        void dumpQiskit(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg, const char* anc_reg_name) const override {
             for (auto& op: ops) {
                 op->dumpQiskit(of, qreg, creg, anc_reg_name);
             }
@@ -168,6 +145,24 @@ namespace qc {
         void                                              resize(size_t count) { ops.resize(count); }
         std::vector<std::unique_ptr<Operation>>::iterator erase(std::vector<std::unique_ptr<Operation>>::const_iterator pos) { return ops.erase(pos); }
         std::vector<std::unique_ptr<Operation>>::iterator erase(std::vector<std::unique_ptr<Operation>>::const_iterator first, std::vector<std::unique_ptr<Operation>>::const_iterator last) { return ops.erase(first, last); }
+        template<class T>
+        void emplace_back(std::unique_ptr<T>& op) {
+            parameter[0]++;
+            ops.emplace_back(std::move(op));
+        }
+        template<class T, class... Args>
+        void emplace_back(Args&&... args) {
+            parameter[0]++;
+            ops.emplace_back(std::make_unique<T>(args...));
+        }
+        template<class T, class... Args>
+        std::vector<std::unique_ptr<Operation>>::iterator insert(std::vector<std::unique_ptr<Operation>>::const_iterator iterator, Args&&... args) {
+            return ops.insert(iterator, std::make_unique<T>(args...));
+        }
+        template<class T>
+        std::vector<std::unique_ptr<Operation>>::iterator insert(std::vector<std::unique_ptr<Operation>>::const_iterator iterator, std::unique_ptr<T>& op) {
+            return ops.insert(iterator, std::move(op));
+        }
     };
 } // namespace qc
 #endif //QFR_COMPOUNDOPERATION_H

--- a/include/operations/CompoundOperation.hpp
+++ b/include/operations/CompoundOperation.hpp
@@ -40,7 +40,7 @@ namespace qc {
         }
 
         [[nodiscard]] bool isNonUnitaryOperation() const override {
-            return std::any_of(ops.cbegin(), ops.cend(), [] (const auto& op) { return op->isNonUnitaryOperation(); });
+            return std::any_of(ops.cbegin(), ops.cend(), [](const auto& op) { return op->isNonUnitaryOperation(); });
         }
 
         MatrixDD getDD(std::unique_ptr<dd::Package>& dd) const override {
@@ -83,7 +83,8 @@ namespace qc {
                 op->print(os);
             }
 
-            return os;        }
+            return os;
+        }
 
         std::ostream& print(std::ostream& os, const Permutation& permutation) const override {
             os << name;
@@ -97,7 +98,7 @@ namespace qc {
         }
 
         [[nodiscard]] bool actsOn(dd::Qubit i) const override {
-            return std::any_of(ops.cbegin(), ops.cend(), [&i] (const auto& op) { return op->actsOn(i);});
+            return std::any_of(ops.cbegin(), ops.cend(), [&i](const auto& op) { return op->actsOn(i); });
         }
 
         void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg) const override {

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -22,7 +22,7 @@ namespace qc {
 
     public:
         // Measurement constructor
-        NonUnitaryOperation(dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, const std::vector<std::size_t>& classicalRegister);
+        NonUnitaryOperation(dd::QubitCount nq, std::vector<dd::Qubit> qubitRegister, std::vector<std::size_t> classicalRegister);
         NonUnitaryOperation(dd::QubitCount nq, dd::Qubit qubit, std::size_t cbit);
 
         // Snapshot constructor

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -10,30 +10,32 @@
 
 namespace qc {
 
-    class NonUnitaryOperation: public Operation {
+    class NonUnitaryOperation final: public Operation {
+    protected:
+        std::vector<dd::Qubit> qubits{}; // vector for the qubits to measure (necessary since std::set does not preserve the order of inserted elements)
+        std::vector<std::size_t> classics{}; // vector for the classical bits to measure into
+
+        std::ostream& printNonUnitary(std::ostream& os, const std::vector<dd::Qubit>& q, const std::vector<std::size_t>& c = {}) const;
+
+        MatrixDD getDD(std::unique_ptr<dd::Package>& dd, const dd::Controls& controls, const Targets& targets) const override;
+        MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd, const dd::Controls& controls, const Targets& targets) const override;
+
     public:
         // Measurement constructor
-        NonUnitaryOperation(unsigned short nq, const std::vector<unsigned short>& qubitRegister, const std::vector<unsigned short>& classicalRegister);
-        NonUnitaryOperation(unsigned short nq, unsigned short qubit, unsigned short clbit);
+        NonUnitaryOperation(dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, const std::vector<std::size_t>& classicalRegister);
+        NonUnitaryOperation(dd::QubitCount nq, dd::Qubit qubit, std::size_t cbit);
 
         // Snapshot constructor
-        NonUnitaryOperation(unsigned short nq, const std::vector<unsigned short>& qubitRegister, int n);
+        NonUnitaryOperation(dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, std::size_t n);
 
         // ShowProbabilities constructor
-        explicit NonUnitaryOperation(const unsigned short nq) {
+        explicit NonUnitaryOperation(const dd::QubitCount nq) {
             nqubits = nq;
             type    = ShowProbabilities;
         }
 
         // General constructor
-        NonUnitaryOperation(unsigned short nq, const std::vector<unsigned short>& qubitRegister, OpType op = Reset);
-
-        dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line) const override;
-        dd::Edge getInverseDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line) const override;
-        dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, std::map<unsigned short, unsigned short>&) const override;
-        dd::Edge getInverseDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, std::map<unsigned short, unsigned short>&) const override {
-            return getInverseDD(dd, line);
-        }
+        NonUnitaryOperation(dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, OpType op = Reset);
 
         [[nodiscard]] bool isUnitary() const override {
             return false;
@@ -43,15 +45,64 @@ namespace qc {
             return true;
         }
 
-        [[nodiscard]] bool actsOn(unsigned short i) const override;
+        [[nodiscard]] const Targets& getTargets() const override {
+            if (type == Measure)
+                return qubits;
+            else
+                return targets;
+        }
+        Targets& getTargets() override {
+            if (type == Measure)
+                return qubits;
+            else
+                return targets;
+        }
+        [[nodiscard]] size_t getNtargets() const override {
+            return getTargets().size();
+        }
 
-        std::ostream& print(std::ostream& os) const override;
+        [[nodiscard]] const std::vector<std::size_t>& getClassics() const {
+            return classics;
+        }
+        std::vector<std::size_t>& getClassics() {
+            return classics;
+        }
+        [[nodiscard]] size_t getNclassics() const {
+            return classics.size();
+        }
 
-        void dumpOpenQASM(std::ostream& of, const regnames_t& qreg, const regnames_t& creg) const override;
-        void dumpQiskit(std::ostream& of, const regnames_t& qreg, const regnames_t& creg, const char* anc_reg_name) const override;
-        void dumpReal([[maybe_unused]] std::ostream& of) const override{};
+        [[nodiscard]] bool actsOn(dd::Qubit i) const override;
 
-        std::ostream& print(std::ostream& os, const std::map<unsigned short, unsigned short>& permutation) const override;
+        std::ostream& print(std::ostream& os) const override {
+            if (type == Measure) {
+                return printNonUnitary(os, qubits, classics);
+            } else {
+                return printNonUnitary(os, targets);
+            }
+        }
+        std::ostream& print(std::ostream& os, const Permutation& permutation) const override {
+            if (type == Measure) {
+                return printNonUnitary(os, permutation.apply(qubits), classics);
+            } else {
+                return printNonUnitary(os, permutation.apply(targets));
+            }
+        }
+
+        MatrixDD getDD(std::unique_ptr<dd::Package>& dd) const override {
+            return Operation::getDD(dd);
+        }
+        MatrixDD getDD(std::unique_ptr<dd::Package>& dd, Permutation& permutation) const override {
+            return Operation::getDD(dd, permutation);
+        }
+        MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd) const override {
+            return Operation::getInverseDD(dd);
+        }
+        MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd, Permutation& permutation) const override {
+            return Operation::getInverseDD(dd, permutation);
+        }
+
+        void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg) const override;
+        void dumpQiskit(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg, const char* anc_reg_name) const override;
     };
 } // namespace qc
 #endif //QFR_NONUNITARYOPERATION_H

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -12,7 +12,7 @@ namespace qc {
 
     class NonUnitaryOperation final: public Operation {
     protected:
-        std::vector<dd::Qubit> qubits{}; // vector for the qubits to measure (necessary since std::set does not preserve the order of inserted elements)
+        std::vector<dd::Qubit>   qubits{};   // vector for the qubits to measure (necessary since std::set does not preserve the order of inserted elements)
         std::vector<std::size_t> classics{}; // vector for the classical bits to measure into
 
         std::ostream& printNonUnitary(std::ostream& os, const std::vector<dd::Qubit>& q, const std::vector<std::size_t>& c = {}) const;

--- a/include/operations/Operation.hpp
+++ b/include/operations/Operation.hpp
@@ -72,7 +72,6 @@ namespace qc {
 
         dd::QubitCount nqubits    = 0;
         OpType         type       = None;  // Op type
-        bool           controlled = false; // flag to distinguish multi control operations
         char           name[MAX_STRING_LENGTH]{};
 
         static bool isWholeQubitRegister(const RegisterNames& reg, std::size_t start, std::size_t end) {
@@ -155,10 +154,6 @@ namespace qc {
             Operation::parameter = p;
         }
 
-        virtual void setControlled(bool contr) {
-            controlled = contr;
-        }
-
         // Public Methods
         // The methods with a permutation parameter apply these operations according to the mapping specified by the permutation, e.g.
         //      if perm[0] = 1 and perm[1] = 0
@@ -198,7 +193,7 @@ namespace qc {
         }
 
         [[nodiscard]] inline virtual bool isControlled() const {
-            return controlled;
+            return !controls.empty();
         }
 
         [[nodiscard]] inline virtual bool actsOn(dd::Qubit i) const {

--- a/include/operations/Operation.hpp
+++ b/include/operations/Operation.hpp
@@ -70,8 +70,8 @@ namespace qc {
         Targets                            targets{};
         std::array<dd::fp, MAX_PARAMETERS> parameter{};
 
-        dd::QubitCount nqubits    = 0;
-        OpType         type       = None;  // Op type
+        dd::QubitCount nqubits = 0;
+        OpType         type    = None; // Op type
         char           name[MAX_STRING_LENGTH]{};
 
         static bool isWholeQubitRegister(const RegisterNames& reg, std::size_t start, std::size_t end) {

--- a/include/operations/Operation.hpp
+++ b/include/operations/Operation.hpp
@@ -6,8 +6,8 @@
 #ifndef QFR_OPERATION_H
 #define QFR_OPERATION_H
 
-#include "DDexport.h"
-#include "DDpackage.h"
+#include "Definitions.hpp"
+#include "dd/Package.hpp"
 
 #include <array>
 #include <cstring>
@@ -16,58 +16,13 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <set>
 #include <vector>
 
-#define DEBUG_MODE_OPERATIONS 0
-
 namespace qc {
-    class QFRException: public std::invalid_argument {
-        std::string msg;
-
-    public:
-        explicit QFRException(std::string msg):
-            std::invalid_argument("QFR Exception"), msg(std::move(msg)) {}
-
-        [[nodiscard]] const char* what() const noexcept override {
-            return msg.c_str();
-        }
-    };
-
-    using regnames_t = std::vector<std::pair<std::string, std::string>>;
-    enum Format {
-        Real,
-        OpenQASM,
-        GRCS,
-        Qiskit,
-        TFC,
-        QC
-    };
-
-    struct Control {
-        enum controlType : bool { pos = true,
-                                  neg = false };
-
-        unsigned short qubit = 0;
-        controlType    type  = pos;
-
-        explicit Control(unsigned short qubit = 0, controlType type = pos):
-            qubit(qubit), type(type){};
-    };
-
-    // Math Constants
-    static constexpr fp PI   = 3.141592653589793238462643383279502884197169399375105820974L;
-    static constexpr fp PI_2 = 1.570796326794896619231321691639751442098584699687552910487L;
-    static constexpr fp PI_4 = 0.785398163397448309615660845819875721049292349843776455243L;
-
     // Operation Constants
-    constexpr std::size_t MAX_QUBITS        = dd::MAXN; // Max. qubits supported
-    constexpr std::size_t MAX_PARAMETERS    = 3;        // Max. parameters of an operation
-    constexpr std::size_t MAX_STRING_LENGTH = 20;       // Ensure short-string-optimizations
-
-    static constexpr short LINE_TARGET      = dd::RADIX;
-    static constexpr short LINE_CONTROL_POS = 1;
-    static constexpr short LINE_CONTROL_NEG = 0;
-    static constexpr short LINE_DEFAULT     = -1;
+    constexpr std::size_t MAX_PARAMETERS    = 3;  // Max. parameters of an operation
+    constexpr std::size_t MAX_STRING_LENGTH = 20; // Ensure short-string-optimizations
 
     // Supported Operations
     enum OpType {
@@ -111,27 +66,22 @@ namespace qc {
 
     class Operation {
     protected:
-        std::vector<unsigned short>    targets{};
-        std::vector<Control>           controls{};
-        std::array<fp, MAX_PARAMETERS> parameter{};
+        dd::Controls                       controls{};
+        Targets                            targets{};
+        std::array<dd::fp, MAX_PARAMETERS> parameter{};
 
-        unsigned short nqubits     = 0;
-        OpType         type        = None;  // Op type
-        bool           multiTarget = false; // flag to distinguish multi target operations
-        bool           controlled  = false; // flag to distinguish multi control operations
+        dd::QubitCount nqubits    = 0;
+        OpType         type       = None;  // Op type
+        bool           controlled = false; // flag to distinguish multi control operations
         char           name[MAX_STRING_LENGTH]{};
 
-        static bool isWholeQubitRegister(const regnames_t& reg, unsigned short start, unsigned short end) {
+        static bool isWholeQubitRegister(const RegisterNames& reg, std::size_t start, std::size_t end) {
             return !reg.empty() && reg[start].first == reg[end].first && (start == 0 || reg[start].first != reg[start - 1].first) && (end == reg.size() - 1 || reg[end].first != reg[end + 1].first);
         }
 
-        static std::map<unsigned short, unsigned short> create_standard_permutation() {
-            std::map<unsigned short, unsigned short> permutation{};
-            for (unsigned short i = 0; i < MAX_QUBITS; ++i)
-                permutation.insert({i, i});
-            return permutation;
-        }
-        static std::map<unsigned short, unsigned short> standardPermutation;
+        virtual MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd, const dd::Controls& controls, const Targets& targets) const = 0;
+
+        virtual MatrixDD getDD(std::unique_ptr<dd::Package>& dd, const dd::Controls& controls, const Targets& targets) const = 0;
 
     public:
         Operation()                        = default;
@@ -143,34 +93,34 @@ namespace qc {
         virtual ~Operation() = default;
 
         // Getters
-        [[nodiscard]] const std::vector<unsigned short>& getTargets() const {
+        [[nodiscard]] virtual const Targets& getTargets() const {
             return targets;
         }
-        std::vector<unsigned short>& getTargets() {
+        virtual Targets& getTargets() {
             return targets;
         }
-        [[nodiscard]] size_t getNtargets() const {
+        [[nodiscard]] virtual std::size_t getNtargets() const {
             return targets.size();
         }
 
-        [[nodiscard]] const std::vector<Control>& getControls() const {
+        [[nodiscard]] const dd::Controls& getControls() const {
             return controls;
         }
-        std::vector<Control>& getControls() {
+        dd::Controls& getControls() {
             return controls;
         }
-        [[nodiscard]] size_t getNcontrols() const {
+        [[nodiscard]] std::size_t getNcontrols() const {
             return controls.size();
         }
 
-        [[nodiscard]] unsigned short getNqubits() const {
+        [[nodiscard]] dd::QubitCount getNqubits() const {
             return nqubits;
         }
 
-        [[nodiscard]] const std::array<fp, MAX_PARAMETERS>& getParameter() const {
+        [[nodiscard]] const std::array<dd::fp, MAX_PARAMETERS>& getParameter() const {
             return parameter;
         }
-        std::array<fp, MAX_PARAMETERS>& getParameter() {
+        std::array<dd::fp, MAX_PARAMETERS>& getParameter() {
             return parameter;
         }
 
@@ -182,16 +132,16 @@ namespace qc {
         }
 
         // Setter
-        virtual void setNqubits(unsigned short nq) {
+        virtual void setNqubits(dd::QubitCount nq) {
             nqubits = nq;
         }
 
-        virtual void setTargets(const std::vector<unsigned short>& t) {
-            Operation::targets = t;
+        virtual void setTargets(const Targets& t) {
+            targets = t;
         }
 
-        virtual void setControls(const std::vector<Control>& c) {
-            Operation::controls = c;
+        virtual void setControls(const dd::Controls& c) {
+            controls = c;
         }
 
         virtual void setName();
@@ -201,7 +151,7 @@ namespace qc {
             setName();
         }
 
-        virtual void setParameter(const std::array<fp, MAX_PARAMETERS>& p) {
+        virtual void setParameter(const std::array<dd::fp, MAX_PARAMETERS>& p) {
             Operation::parameter = p;
         }
 
@@ -209,28 +159,23 @@ namespace qc {
             controlled = contr;
         }
 
-        virtual void setMultiTarget(bool multi) {
-            multiTarget = multi;
-        }
-
         // Public Methods
         // The methods with a permutation parameter apply these operations according to the mapping specified by the permutation, e.g.
         //      if perm[0] = 1 and perm[1] = 0
         //      then cx 0 1 will be translated to cx perm[0] perm[1] == cx 1 0
-        virtual void setLine(std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation) const;
-        void         setLine(std::array<short, MAX_QUBITS>& line) const {
-            setLine(line, standardPermutation);
+        virtual MatrixDD getDD(std::unique_ptr<dd::Package>& dd) const {
+            return getDD(dd, controls, targets);
         }
-        virtual void resetLine(std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation) const;
-        void         resetLine(std::array<short, MAX_QUBITS>& line) const {
-            resetLine(line, standardPermutation);
+        virtual MatrixDD getDD(std::unique_ptr<dd::Package>& dd, Permutation& permutation) const {
+            return getDD(dd, permutation.apply(controls), permutation.apply(targets));
         }
 
-        virtual dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line) const                                                        = 0;
-        virtual dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, std::map<unsigned short, unsigned short>& permutation) const = 0;
-
-        virtual dd::Edge getInverseDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line) const                                                        = 0;
-        virtual dd::Edge getInverseDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, std::map<unsigned short, unsigned short>& permutation) const = 0;
+        virtual MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd) const {
+            return getInverseDD(dd, controls, targets);
+        }
+        virtual MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd, Permutation& permutation) const {
+            return getInverseDD(dd, permutation.apply(controls), permutation.apply(targets));
+        }
 
         [[nodiscard]] inline virtual bool isUnitary() const {
             return true;
@@ -256,32 +201,28 @@ namespace qc {
             return controlled;
         }
 
-        [[nodiscard]] inline virtual bool isMultiTarget() const {
-            return multiTarget;
-        }
-
-        [[nodiscard]] inline virtual bool actsOn(unsigned short i) const {
+        [[nodiscard]] inline virtual bool actsOn(dd::Qubit i) const {
             for (const auto& t: targets) {
                 if (t == i)
                     return true;
             }
 
-            if (std::any_of(controls.cbegin(), controls.cend(), [&i](const Control& c) { return c.qubit == i; }))
+            if (controls.count(i) > 0)
                 return true;
 
             return false;
         }
 
+        virtual std::ostream& printParameters(std::ostream& os) const;
         virtual std::ostream& print(std::ostream& os) const;
-        virtual std::ostream& print(std::ostream& os, const std::map<unsigned short, unsigned short>& permutation) const;
+        virtual std::ostream& print(std::ostream& os, const Permutation& permutation) const;
 
         friend std::ostream& operator<<(std::ostream& os, const Operation& op) {
             return op.print(os);
         }
 
-        virtual void dumpOpenQASM(std::ostream& of, const regnames_t& qreg, const regnames_t& creg) const                         = 0;
-        virtual void dumpReal(std::ostream& of) const                                                                             = 0;
-        virtual void dumpQiskit(std::ostream& of, const regnames_t& qreg, const regnames_t& creg, const char* anc_reg_name) const = 0;
+        virtual void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg) const                         = 0;
+        virtual void dumpQiskit(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg, const char* anc_reg_name) const = 0;
     };
 } // namespace qc
 #endif //QFR_OPERATION_H

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -6,81 +6,92 @@
 #ifndef QFR_STANDARDOPERATION_H
 #define QFR_STANDARDOPERATION_H
 
-#include "DDpackage.h"
-#include "GateMatrixDefinitions.h"
 #include "Operation.hpp"
+#include "dd/GateMatrixDefinitions.hpp"
 
 namespace qc {
-    using GateMatrix = std::array<dd::ComplexValue, dd::NEDGE>;
 
-    //constexpr long double PARAMETER_TOLERANCE = dd::ComplexNumbers::TOLERANCE * 10e-2;
-    constexpr fp PARAMETER_TOLERANCE = 10e-6;
-    inline bool  fp_equals(const fp a, const fp b) { return (std::abs(a - b) < PARAMETER_TOLERANCE); }
+    constexpr dd::fp PARAMETER_TOLERANCE = 10e-6;
+    inline bool      fp_equals(const dd::fp a, const dd::fp b) { return (std::abs(a - b) < PARAMETER_TOLERANCE); }
 
-    class StandardOperation: public Operation {
+    class StandardOperation final: public Operation {
     protected:
-        static void checkInteger(fp& ld) {
+        static void checkInteger(dd::fp& ld) {
             auto nearest = std::nearbyint(ld);
             if (std::abs(ld - nearest) < PARAMETER_TOLERANCE) {
                 ld = nearest;
             }
         }
 
-        static void checkFractionPi(fp& ld) {
-            auto div     = qc::PI / ld;
+        static void checkFractionPi(dd::fp& ld) {
+            auto div     = dd::PI / ld;
             auto nearest = std::nearbyint(div);
             if (std::abs(div - nearest) < PARAMETER_TOLERANCE) {
-                ld = qc::PI / nearest;
+                ld = dd::PI / nearest;
             }
         }
 
-        static OpType parseU3(fp& lambda, fp& phi, fp& theta);
-        static OpType parseU2(fp& lambda, fp& phi);
-        static OpType parseU1(fp& lambda);
+        static OpType parseU3(dd::fp& lambda, dd::fp& phi, dd::fp& theta);
+        static OpType parseU2(dd::fp& lambda, dd::fp& phi);
+        static OpType parseU1(dd::fp& lambda);
 
         void checkUgate();
-        void setup(unsigned short nq, fp par0, fp par1, fp par2);
+        void setup(dd::QubitCount nq, dd::fp par0, dd::fp par1, dd::fp par2);
 
-        dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, bool inverse, const std::map<unsigned short, unsigned short>& permutation = standardPermutation) const;
+        // single-target operations
+        MatrixDD getStandardOperationDD(std::unique_ptr<dd::Package>& dd, const dd::Controls& controls, dd::Qubit target, bool inverse) const;
+        // two-target operations
+        MatrixDD getStandardOperationDD(std::unique_ptr<dd::Package>& dd, const dd::Controls& controls, dd::Qubit target0, dd::Qubit target1, bool inverse) const;
+
+        MatrixDD getDD(std::unique_ptr<dd::Package>& dd, const dd::Controls& controls, const Targets& targets) const override {
+            if (type == SWAP || type == iSWAP || type == Peres || type == Peresdag) {
+                assert(targets.size() == 2);
+                return getStandardOperationDD(dd, controls, targets[0], targets[1], false);
+            } else {
+                assert(targets.size() == 1);
+                return getStandardOperationDD(dd, controls, targets[0], false);
+            }
+        }
+        MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd, const dd::Controls& controls, const Targets& targets) const override {
+            if (type == SWAP || type == iSWAP || type == Peres || type == Peresdag) {
+                assert(targets.size() == 2);
+                return getStandardOperationDD(dd, controls, targets[0], targets[1], true);
+            } else {
+                assert(targets.size() == 1);
+                return getStandardOperationDD(dd, controls, targets[0], true);
+            }
+        }
 
     public:
         StandardOperation() = default;
 
         // Standard Constructors
-        StandardOperation(unsigned short nq, unsigned short target, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0.);
-        StandardOperation(unsigned short nq, const std::vector<unsigned short>& targets, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0.);
+        StandardOperation(dd::QubitCount nq, dd::Qubit target, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0.);
+        StandardOperation(dd::QubitCount nq, const Targets& targets, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0.);
 
-        StandardOperation(unsigned short nq, Control control, unsigned short target, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0.);
-        StandardOperation(unsigned short nq, Control control, const std::vector<unsigned short>& targets, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0.);
+        StandardOperation(dd::QubitCount nq, dd::Control control, dd::Qubit target, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0.);
+        StandardOperation(dd::QubitCount nq, dd::Control control, const Targets& targets, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0.);
 
-        StandardOperation(unsigned short nq, const std::vector<Control>& controls, unsigned short target, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0.);
-        StandardOperation(unsigned short nq, const std::vector<Control>& controls, const std::vector<unsigned short>& targets, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0.);
+        StandardOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0.);
+        StandardOperation(dd::QubitCount nq, const dd::Controls& controls, const Targets& targets, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0.);
 
         // MCT Constructor
-        StandardOperation(unsigned short nq, const std::vector<Control>& controls, unsigned short target);
+        StandardOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target);
 
         // MCF (cSWAP), Peres, paramterized two target Constructor
-        StandardOperation(unsigned short nq, const std::vector<Control>& controls, unsigned short target0, unsigned short target1, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0.);
+        StandardOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target0, dd::Qubit target1, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0.);
 
         [[nodiscard]] bool isStandardOperation() const override {
             return true;
         }
 
-        dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line) const override;
-        dd::Edge getDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, std::map<unsigned short, unsigned short>& permutation) const override;
+        MatrixDD getDD(std::unique_ptr<dd::Package>& dd) const override { return Operation::getDD(dd); }
+        MatrixDD getDD(std::unique_ptr<dd::Package>& dd, Permutation& permutation) const override;
+        MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd) const override { return Operation::getInverseDD(dd); }
+        MatrixDD getInverseDD(std::unique_ptr<dd::Package>& dd, Permutation& permutation) const override;
 
-        dd::Edge getInverseDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line) const override;
-        dd::Edge getInverseDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, std::map<unsigned short, unsigned short>& permutation) const override;
-
-        dd::Edge getSWAPDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation = standardPermutation) const;
-        dd::Edge getPeresDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation = standardPermutation) const;
-        dd::Edge getPeresdagDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation = standardPermutation) const;
-        dd::Edge getiSWAPDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation = standardPermutation) const;
-        dd::Edge getiSWAPinvDD(std::unique_ptr<dd::Package>& dd, std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation = standardPermutation) const;
-
-        void dumpOpenQASM(std::ostream& of, const regnames_t& qreg, const regnames_t& creg) const override;
-        void dumpReal(std::ostream& of) const override;
-        void dumpQiskit(std::ostream& of, const regnames_t& qreg, const regnames_t& creg, const char* anc_reg_name) const override;
+        void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg) const override;
+        void dumpQiskit(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg, const char* anc_reg_name) const override;
     };
 
 } // namespace qc

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -10,10 +10,6 @@
 #include "dd/GateMatrixDefinitions.hpp"
 
 namespace qc {
-
-    constexpr dd::fp PARAMETER_TOLERANCE = 10e-6;
-    inline bool      fp_equals(const dd::fp a, const dd::fp b) { return (std::abs(a - b) < PARAMETER_TOLERANCE); }
-
     class StandardOperation final: public Operation {
     protected:
         static void checkInteger(dd::fp& ld) {

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -13,15 +13,15 @@ namespace qc {
     class StandardOperation final: public Operation {
     protected:
         static void checkInteger(dd::fp& ld) {
-            auto nearest = std::nearbyint(ld);
+            dd::fp nearest = std::nearbyint(ld);
             if (std::abs(ld - nearest) < PARAMETER_TOLERANCE) {
                 ld = nearest;
             }
         }
 
         static void checkFractionPi(dd::fp& ld) {
-            auto div     = dd::PI / ld;
-            auto nearest = std::nearbyint(div);
+            dd::fp div     = dd::PI / ld;
+            dd::fp nearest = std::nearbyint(div);
             if (std::abs(div - nearest) < PARAMETER_TOLERANCE) {
                 ld = dd::PI / nearest;
             }

--- a/include/parsers/qasm_parser/Token.hpp
+++ b/include/parsers/qasm_parser/Token.hpp
@@ -6,7 +6,7 @@
 #ifndef QFR_TOKEN_H
 #define QFR_TOKEN_H
 
-#include "DDcomplex.h"
+#include "dd/Definitions.hpp"
 
 #include <map>
 #include <string>
@@ -69,7 +69,7 @@ namespace qasm {
         int         line    = 0;
         int         col     = 0;
         int         val     = 0;
-        fp          valReal = 0.0;
+        dd::fp      valReal = 0.0;
         std::string str;
 
         Token() = default;

--- a/jkq/qfr/CMakeLists.txt
+++ b/jkq/qfr/CMakeLists.txt
@@ -19,9 +19,4 @@ add_library(JKQ::${PROJECT_NAME}_python ALIAS ${PROJECT_NAME}_python)
 # add pyqfr module
 pybind11_add_module(py${PROJECT_NAME} bindings.cpp)
 target_link_libraries(py${PROJECT_NAME} PUBLIC ${PROJECT_NAME} JKQ::${PROJECT_NAME}_python pybind11_json)
-# enable interprocedural optimization if it is supported
-include(CheckIPOSupported)
-check_ipo_supported(RESULT ipo_supported)
-if (ipo_supported)
-	set_target_properties(py${PROJECT_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
-endif ()
+enable_lto(py${PROJECT_NAME})

--- a/jkq/qfr/CMakeLists.txt
+++ b/jkq/qfr/CMakeLists.txt
@@ -19,3 +19,9 @@ add_library(JKQ::${PROJECT_NAME}_python ALIAS ${PROJECT_NAME}_python)
 # add pyqfr module
 pybind11_add_module(py${PROJECT_NAME} bindings.cpp)
 target_link_libraries(py${PROJECT_NAME} PUBLIC ${PROJECT_NAME} JKQ::${PROJECT_NAME}_python pybind11_json)
+# enable interprocedural optimization if it is supported
+include(CheckIPOSupported)
+check_ipo_supported(RESULT ipo_supported)
+if (ipo_supported)
+	set_target_properties(py${PROJECT_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif ()

--- a/jkq/qfr/QiskitImport.hpp
+++ b/jkq/qfr/QiskitImport.hpp
@@ -215,7 +215,7 @@ namespace qc {
 
         // import initial layout in case it is available
         if (!circ.attr("_layout").is_none()) {
-            auto&&         virtual_bits        = circ.attr("_layout").attr("get_virtual_bits")().cast<py::dict>();
+            auto&&    virtual_bits        = circ.attr("_layout").attr("get_virtual_bits")().cast<py::dict>();
             dd::Qubit logical_qubit_index = 0;
             for (auto qubit: virtual_bits) {
                 auto&& logical_qubit = qubit.first;

--- a/jkq/qfr/QiskitImport.hpp
+++ b/jkq/qfr/QiskitImport.hpp
@@ -53,53 +53,55 @@ namespace qc {
     }
 
     void addQiskitOperation(QuantumComputation& qc, qc::OpType type, const py::list& qargs, const py::list& params) {
-        std::vector<qc::Control> qubits{};
+        std::vector<dd::Control> qubits{};
         for (const auto qubit: qargs) {
-            auto&&         qreg   = qubit.attr("register").attr("name").cast<std::string>();
-            auto&&         qidx   = qubit.attr("index").cast<unsigned short>();
-            unsigned short target = qc.getIndexFromQubitRegister({qreg, qidx});
-            qubits.emplace_back(target);
+            auto&&    qreg   = qubit.attr("register").attr("name").cast<std::string>();
+            auto&&    qidx   = qubit.attr("index").cast<dd::Qubit>();
+            dd::Qubit target = qc.getIndexFromQubitRegister({qreg, qidx});
+            qubits.emplace_back(dd::Control{target});
         }
         auto target = qubits.back().qubit;
         qubits.pop_back();
-        fp theta = 0., phi = 0., lambda = 0.;
+        dd::fp theta = 0., phi = 0., lambda = 0.;
         if (params.size() == 1) {
-            lambda = params[0].cast<fp>();
+            lambda = params[0].cast<dd::fp>();
         } else if (params.size() == 2) {
-            phi    = params[0].cast<fp>();
-            lambda = params[1].cast<fp>();
+            phi    = params[0].cast<dd::fp>();
+            lambda = params[1].cast<dd::fp>();
         } else if (params.size() == 3) {
-            theta  = params[0].cast<fp>();
-            phi    = params[1].cast<fp>();
-            lambda = params[2].cast<fp>();
+            theta  = params[0].cast<dd::fp>();
+            phi    = params[1].cast<dd::fp>();
+            lambda = params[2].cast<dd::fp>();
         }
-        qc.emplace_back<qc::StandardOperation>(qc.getNqubits(), qubits, target, type, lambda, phi, theta);
+        dd::Controls controls(qubits.cbegin(), qubits.cend());
+        qc.emplace_back<qc::StandardOperation>(qc.getNqubits(), controls, target, type, lambda, phi, theta);
     }
 
     void addTwoTargetQiskitOperation(QuantumComputation& qc, qc::OpType type, const py::list& qargs, const py::list& params) {
-        std::vector<qc::Control> qubits{};
+        std::vector<dd::Control> qubits{};
         for (const auto qubit: qargs) {
-            auto&&         qreg   = qubit.attr("register").attr("name").cast<std::string>();
-            auto&&         qidx   = qubit.attr("index").cast<unsigned short>();
-            unsigned short target = qc.getIndexFromQubitRegister({qreg, qidx});
-            qubits.emplace_back(target);
+            auto&&    qreg   = qubit.attr("register").attr("name").cast<std::string>();
+            auto&&    qidx   = qubit.attr("index").cast<dd::Qubit>();
+            dd::Qubit target = qc.getIndexFromQubitRegister({qreg, qidx});
+            qubits.emplace_back(dd::Control{target});
         }
         auto target1 = qubits.back().qubit;
         qubits.pop_back();
         auto target0 = qubits.back().qubit;
         qubits.pop_back();
-        fp theta = 0., phi = 0., lambda = 0.;
+        dd::fp theta = 0., phi = 0., lambda = 0.;
         if (params.size() == 1) {
-            lambda = params[0].cast<fp>();
+            lambda = params[0].cast<dd::fp>();
         } else if (params.size() == 2) {
-            phi    = params[0].cast<fp>();
-            lambda = params[1].cast<fp>();
+            phi    = params[0].cast<dd::fp>();
+            lambda = params[1].cast<dd::fp>();
         } else if (params.size() == 3) {
-            theta  = params[0].cast<fp>();
-            phi    = params[1].cast<fp>();
-            lambda = params[2].cast<fp>();
+            theta  = params[0].cast<dd::fp>();
+            phi    = params[1].cast<dd::fp>();
+            lambda = params[2].cast<dd::fp>();
         }
-        qc.emplace_back<qc::StandardOperation>(qc.getNqubits(), qubits, target0, target1, type, lambda, phi, theta);
+        dd::Controls controls(qubits.cbegin(), qubits.cend());
+        qc.emplace_back<qc::StandardOperation>(qc.getNqubits(), controls, target0, target1, type, lambda, phi, theta);
     }
 
     void emplaceQiskitOperation(QuantumComputation& qc, const py::object& instruction, const py::list& qargs, const py::list& cargs, const py::list& params) {
@@ -107,21 +109,21 @@ namespace qc {
 
         auto instructionName = instruction.attr("name").cast<std::string>();
         if (instructionName == "measure") {
-            auto&&         qubit   = qargs[0];
-            auto&&         clbit   = cargs[0];
-            auto&&         qreg    = qubit.attr("register").attr("name").cast<std::string>();
-            auto&&         creg    = clbit.attr("register").attr("name").cast<std::string>();
-            auto&&         qidx    = qubit.attr("index").cast<unsigned short>();
-            auto&&         cidx    = clbit.attr("index").cast<unsigned short>();
-            unsigned short control = qc.getIndexFromQubitRegister({qreg, qidx});
-            unsigned short target  = qc.getIndexFromClassicalRegister({creg, cidx});
+            auto&&      qubit   = qargs[0];
+            auto&&      clbit   = cargs[0];
+            auto&&      qreg    = qubit.attr("register").attr("name").cast<std::string>();
+            auto&&      creg    = clbit.attr("register").attr("name").cast<std::string>();
+            auto&&      qidx    = qubit.attr("index").cast<dd::Qubit>();
+            auto&&      cidx    = clbit.attr("index").cast<std::size_t>();
+            dd::Qubit   control = qc.getIndexFromQubitRegister({qreg, qidx});
+            std::size_t target  = qc.getIndexFromClassicalRegister({creg, cidx});
             qc.emplace_back<qc::NonUnitaryOperation>(qc.getNqubits(), control, target);
         } else if (instructionName == "barrier") {
-            std::vector<unsigned short> targets{};
+            Targets targets{};
             for (const auto qubit: qargs) {
-                auto&&         qreg   = qubit.attr("register").attr("name").cast<std::string>();
-                auto&&         qidx   = qubit.attr("index").cast<unsigned short>();
-                unsigned short target = qc.getIndexFromQubitRegister({qreg, qidx});
+                auto&&    qreg   = qubit.attr("register").attr("name").cast<std::string>();
+                auto&&    qidx   = qubit.attr("index").cast<dd::Qubit>();
+                dd::Qubit target = qc.getIndexFromQubitRegister({qreg, qidx});
                 targets.emplace_back(target);
             }
             qc.emplace_back<qc::NonUnitaryOperation>(qc.getNqubits(), targets, qc::Barrier);
@@ -174,11 +176,11 @@ namespace qc {
                     addQiskitOperation(qc, qc::X, qargs_copy, params);
                 }
             } else if (instructionName == "mcx_vchain") {
-                unsigned short size       = qargs.size();
-                unsigned short ncontrols  = (size + 1) / 2;
-                auto           qargs_copy = qargs.attr("copy")();
+                auto        size       = qargs.size();
+                std::size_t ncontrols  = (size + 1) / 2;
+                auto        qargs_copy = qargs.attr("copy")();
                 // discard ancillaries
-                for (int i = 0; i < ncontrols - 2; ++i) {
+                for (std::size_t i = 0; i < ncontrols - 2; ++i) {
                     qargs_copy.attr("pop")();
                 }
                 addQiskitOperation(qc, qc::X, qargs_copy, params);
@@ -203,24 +205,24 @@ namespace qc {
 
         auto&& circQregs = circ.attr("qregs");
         for (const auto qreg: circQregs) {
-            qc.addQubitRegister(qreg.attr("size").cast<unsigned short>(), qreg.attr("name").cast<std::string>().c_str());
+            qc.addQubitRegister(qreg.attr("size").cast<dd::QubitCount>(), qreg.attr("name").cast<std::string>().c_str());
         }
 
         auto&& circCregs = circ.attr("cregs");
         for (const auto creg: circCregs) {
-            qc.addClassicalRegister(creg.attr("size").cast<unsigned short>(), creg.attr("name").cast<std::string>().c_str());
+            qc.addClassicalRegister(creg.attr("size").cast<std::size_t>(), creg.attr("name").cast<std::string>().c_str());
         }
 
         // import initial layout in case it is available
         if (!circ.attr("_layout").is_none()) {
             auto&&         virtual_bits        = circ.attr("_layout").attr("get_virtual_bits")().cast<py::dict>();
-            unsigned short logical_qubit_index = 0;
+            dd::Qubit logical_qubit_index = 0;
             for (auto qubit: virtual_bits) {
                 auto&& logical_qubit = qubit.first;
                 auto&& register_name = logical_qubit.attr("register").attr("name").cast<std::string>();
                 //				auto&& register_index = logical_qubit.attr("index").cast<unsigned short>();
                 if (register_name != "ancilla") {
-                    qc.initialLayout[qubit.second.cast<unsigned short>()] = logical_qubit_index;
+                    qc.initialLayout[qubit.second.cast<dd::Qubit>()] = logical_qubit_index;
                     ++logical_qubit_index;
                 }
             }

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ with open(README_PATH) as readme_file:
 
 setup(
     name='jkq.qfr',
-    version='1.3.0',
+    version='1.4.0',
     author='Lukas Burgholzer',
     author_email='lukas.burgholzer@jku.at',
     description='QFR - A JKQ tool for Quantum Functionality Representation',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC nlohmann_json)
 include(CheckIPOSupported)
 check_ipo_supported(RESULT ipo_supported)
 if(ipo_supported)
-	set_target_properties(${PROJECT_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+	# LTO causes problems when compiling with clang without a ThinLTO aware linker
+	#set_target_properties(${PROJECT_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
 # set compiler flags depending on compiler

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,11 +61,7 @@ add_subdirectory("${PROJECT_SOURCE_DIR}/extern/json" "extern/json" EXCLUDE_FROM_
 target_link_libraries(${PROJECT_NAME} PUBLIC nlohmann_json)
 
 # enable interprocedural optimization if it is supported
-include(CheckIPOSupported)
-check_ipo_supported(RESULT ipo_supported)
-if (ipo_supported)
-	set_target_properties(${PROJECT_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
-endif ()
+enable_lto(${PROJECT_NAME})
 
 # set compiler flags depending on compiler
 if(MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,10 +63,9 @@ target_link_libraries(${PROJECT_NAME} PUBLIC nlohmann_json)
 # enable interprocedural optimization if it is supported
 include(CheckIPOSupported)
 check_ipo_supported(RESULT ipo_supported)
-if(ipo_supported)
-	# LTO causes problems when compiling with clang without a ThinLTO aware linker
-	#set_target_properties(${PROJECT_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
-endif()
+if (ipo_supported)
+	set_target_properties(${PROJECT_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif ()
 
 # set compiler flags depending on compiler
 if(MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(${PROJECT_NAME}
 
             ${${PROJECT_NAME}_SOURCE_DIR}/include/QuantumComputation.hpp
             ${${PROJECT_NAME}_SOURCE_DIR}/include/CircuitOptimizer.hpp
+            ${${PROJECT_NAME}_SOURCE_DIR}/include/Definitions.hpp
 
             ${${PROJECT_NAME}_SOURCE_DIR}/include/algorithms/QFT.hpp
             ${${PROJECT_NAME}_SOURCE_DIR}/include/algorithms/Grover.hpp
@@ -52,7 +53,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CMAKE_CXX_STANDARD_REQUIRED ON 
 
 # add JKQ::DDpackage library
 add_subdirectory("${PROJECT_SOURCE_DIR}/extern/dd_package" "extern/dd_package")
-target_link_libraries(${PROJECT_NAME} PUBLIC JKQ::DDpackage)
+target_link_libraries(${PROJECT_NAME} PUBLIC JKQ::DDPackage)
 
 # add nlohmann::json library
 set(JSON_BuildTests OFF CACHE INTERNAL "")

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -595,7 +595,7 @@ namespace qc {
             os << std::endl;
         }
         if (!ops.empty()) {
-            os << std::setw((int) std::log10(ops.size()) + 1) << "o: \t\t\t";
+            os << std::setw((int)std::log10(ops.size()) + 1) << "o: \t\t\t";
         } else {
             os << "o: \t\t\t";
         }

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -511,6 +511,12 @@ namespace qc {
         buildFunctionalityRecursive(depth, 0, s, permutation, dd);
         auto e = s.top();
         s.pop();
+
+        // correct permutation if necessary
+        changePermutation(e, permutation, outputPermutation, dd);
+        e = dd->reduceAncillae(e, ancillary);
+        e = dd->reduceGarbage(e, garbage);
+
         return e;
     }
 

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -10,8 +10,8 @@ namespace qc {
     /***
      * Public Methods
      ***/
-    unsigned long long QuantumComputation::getNindividualOps() const {
-        unsigned long long nops = 0;
+    std::size_t QuantumComputation::getNindividualOps() const {
+        std::size_t nops = 0;
         for (const auto& op: ops) {
             if (op->isCompoundOperation()) {
                 auto&& comp = dynamic_cast<CompoundOperation*>(op.get());
@@ -88,8 +88,8 @@ namespace qc {
     void QuantumComputation::initializeIOMapping() {
         // if no initial layout was found during parsing the identity mapping is assumed
         if (initialLayout.empty()) {
-            for (unsigned short i = 0; i < nqubits; ++i)
-                initialLayout.insert({i, i});
+            for (dd::QubitCount i = 0; i < nqubits; ++i)
+                initialLayout.insert({static_cast<dd::Qubit>(i), static_cast<dd::Qubit>(i)});
         }
 
         // try gathering (additional) output permutation information from measurements, e.g., a measurement
@@ -102,9 +102,11 @@ namespace qc {
                     continue;
 
                 auto&& op = (*opIt);
-                for (size_t i = 0; i < op->getNcontrols(); ++i) {
-                    auto qubitidx = op->getControls().at(i).qubit;
-                    auto bitidx   = op->getTargets().at(i);
+                assert(op->getTargets().size() == op->getControls().size());
+                auto targetIt = op->getTargets().cbegin();
+                for (const auto& c: op->getControls()) {
+                    auto qubitidx = c.qubit;
+                    auto bitidx   = *targetIt;
 
                     if (outputPermutationFound) {
                         // output permutation was already set before -> permute existing values
@@ -122,16 +124,17 @@ namespace qc {
                         // directly set permutation if none was set beforehand
                         outputPermutation[qubitidx] = bitidx;
                     }
+                    ++targetIt;
                 }
             }
         }
 
         // if the output permutation is still empty, we assume the identity (i.e., it is equal to the initial layout)
         if (outputPermutation.empty()) {
-            for (unsigned short i = 0; i < nqubits; ++i) {
+            for (dd::QubitCount i = 0; i < nqubits; ++i) {
                 // only add to output permutation if the qubit is actually acted upon
-                if (!isIdleQubit(i))
-                    outputPermutation.insert({i, initialLayout.at(i)});
+                if (!isIdleQubit(static_cast<dd::Qubit>(i)))
+                    outputPermutation.insert({static_cast<dd::Qubit>(i), initialLayout.at(i)});
             }
         }
 
@@ -150,9 +153,12 @@ namespace qc {
         }
     }
 
-    void QuantumComputation::addQubitRegister(unsigned short nq, const char* reg_name) {
-        if (nqubits + nancillae + nq > dd::MAXN) {
-            throw QFRException("[addQubitRegister] Adding additional qubits results in too many qubits " + std::to_string(nqubits + nancillae + nq) + " vs. " + std::to_string(dd::MAXN));
+    void QuantumComputation::addQubitRegister(dd::QubitCount nq, const char* reg_name) {
+        if (static_cast<std::size_t>(nqubits + nancillae + nq) > dd::Package::maxPossibleQubits) {
+            throw QFRException("Requested too many qubits to be handled by the DD package. Qubit datatype only allows up to " +
+                               std::to_string(dd::Package::maxPossibleQubits) + " qubits, while " +
+                               std::to_string(nqubits + nancillae + nq) + " were requested. If you want to use more than " +
+                               std::to_string(dd::Package::maxPossibleQubits) + " qubits, you have to recompile the package with a wider Qubit type in `export/dd_package/include/dd/Definitions.hpp!`");
         }
 
         if (qregs.count(reg_name)) {
@@ -167,8 +173,8 @@ namespace qc {
         }
         assert(nancillae == 0); // should only reach this point if no ancillae are present
 
-        for (unsigned short i = 0; i < nq; ++i) {
-            unsigned short j = nqubits + i;
+        for (dd::QubitCount i = 0; i < nq; ++i) {
+            auto j = static_cast<dd::Qubit>(nqubits + i);
             initialLayout.insert({j, j});
             outputPermutation.insert({j, j});
         }
@@ -177,9 +183,12 @@ namespace qc {
         for (auto& op: ops) {
             op->setNqubits(nqubits + nancillae);
         }
+
+        ancillary.resize(nqubits + nancillae);
+        garbage.resize(nqubits + nancillae);
     }
 
-    void QuantumComputation::addClassicalRegister(unsigned short nc, const char* reg_name) {
+    void QuantumComputation::addClassicalRegister(std::size_t nc, const char* reg_name) {
         if (cregs.count(reg_name)) {
             throw QFRException("[addClassicalRegister] Augmenting existing classical registers is currently not supported");
         }
@@ -188,13 +197,15 @@ namespace qc {
         nclassics += nc;
     }
 
-    void QuantumComputation::addAncillaryRegister(unsigned short nq, const char* reg_name) {
-        if (nqubits + nancillae + nq > dd::MAXN) {
-            throw QFRException("[addAncillaryQubitRegister] Adding additional qubits results in too many qubits " + std::to_string(nqubits + nancillae + nq) + " vs. " + std::to_string(dd::MAXN));
+    void QuantumComputation::addAncillaryRegister(dd::QubitCount nq, const char* reg_name) {
+        if (static_cast<std::size_t>(nqubits + nancillae + nq) > dd::Package::maxPossibleQubits) {
+            throw QFRException("Requested too many qubits to be handled by the DD package. Qubit datatype only allows up to " +
+                               std::to_string(dd::Package::maxPossibleQubits) + " qubits, while " +
+                               std::to_string(nqubits + nancillae + nq) + " were requested. If you want to use more than " +
+                               std::to_string(dd::Package::maxPossibleQubits) + " qubits, you have to recompile the package with a wider Qubit type in `export/dd_package/include/dd/Definitions.hpp!`");
         }
 
-        unsigned short totalqubits = nqubits + nancillae;
-
+        dd::QubitCount totalqubits = nqubits + nancillae;
         if (ancregs.count(reg_name)) {
             auto& reg = ancregs.at(reg_name);
             if (reg.first + reg.second == totalqubits) {
@@ -206,11 +217,13 @@ namespace qc {
             ancregs.insert({reg_name, {totalqubits, nq}});
         }
 
-        for (unsigned short i = 0; i < nq; ++i) {
-            unsigned short j = totalqubits + i;
+        ancillary.resize(totalqubits + nq);
+        garbage.resize(totalqubits + nq);
+        for (dd::QubitCount i = 0; i < nq; ++i) {
+            auto j = static_cast<dd::Qubit>(totalqubits + i);
             initialLayout.insert({j, j});
             outputPermutation.insert({j, j});
-            ancillary.set(j);
+            ancillary[j] = true;
         }
         nancillae += nq;
 
@@ -221,35 +234,18 @@ namespace qc {
 
     // removes the i-th logical qubit and returns the index j it was assigned to in the initial layout
     // i.e., initialLayout[j] = i
-    std::pair<unsigned short, short> QuantumComputation::removeQubit(unsigned short logical_qubit_index) {
-#if DEBUG_MODE_QC
-        std::cout << "Trying to remove logical qubit: " << logical_qubit_index << std::endl;
-#endif
-
+    std::pair<dd::Qubit, dd::Qubit> QuantumComputation::removeQubit(dd::Qubit logical_qubit_index) {
         // Find index of the physical qubit i is assigned to
-        unsigned short physical_qubit_index = 0;
+        dd::Qubit physical_qubit_index = 0;
         for (const auto& Q: initialLayout) {
             if (Q.second == logical_qubit_index)
                 physical_qubit_index = Q.first;
         }
 
-#if DEBUG_MODE_QC
-        std::cout << "Found index " << logical_qubit_index << " is assigned to: " << physical_qubit_index << std::endl;
-        printRegisters(std::cout);
-#endif
-
         // get register and register-index of the corresponding qubit
         auto reg = getQubitRegisterAndIndex(physical_qubit_index);
 
-#if DEBUG_MODE_QC
-        std::cout << "Found register: " << reg.first << ", and index: " << reg.second << std::endl;
-        printRegisters(std::cout);
-#endif
-
         if (physicalQubitIsAncillary(physical_qubit_index)) {
-#if DEBUG_MODE_QC
-            std::cout << physical_qubit_index << " is ancilla" << std::endl;
-#endif
             // first index
             if (reg.second == 0) {
                 // last remaining qubit of register
@@ -274,12 +270,6 @@ namespace qc {
                 auto high_part  = reg.first + "_h";
                 auto high_index = ancreg.first + reg.second + 1;
                 auto high_count = ancreg.second - reg.second - 1;
-
-#if DEBUG_MODE_QC
-                std::cout << "Splitting register: " << reg.first << ", into:" << std::endl;
-                std::cout << low_part << ": {" << low_index << ", " << low_count << "}" << std::endl;
-                std::cout << high_part << ": {" << high_index << ", " << high_count << "}" << std::endl;
-#endif
 
                 ancregs.erase(reg.first);
                 ancregs.insert({low_part, {low_index, low_count}});
@@ -312,12 +302,6 @@ namespace qc {
                 auto high_index = qreg.first + reg.second + 1;
                 auto high_count = qreg.second - reg.second - 1;
 
-#if DEBUG_MODE_QC
-                std::cout << "Splitting register: " << reg.first << ", into:" << std::endl;
-                std::cout << low_part << ": {" << low_index << ", " << low_count << "}" << std::endl;
-                std::cout << high_part << ": {" << high_index << ", " << high_count << "}" << std::endl;
-#endif
-
                 qregs.erase(reg.first);
                 qregs.insert({low_part, {low_index, low_count}});
                 qregs.insert({high_part, {high_index, high_count}});
@@ -326,63 +310,41 @@ namespace qc {
             nqubits--;
         }
 
-#if DEBUG_MODE_QC
-        std::cout << "Updated registers: " << std::endl;
-        printRegisters(std::cout);
-        std::cout << "nqubits: " << nqubits << ", nancillae: " << nancillae << std::endl;
-#endif
-
         // adjust initial layout permutation
         initialLayout.erase(physical_qubit_index);
 
-#if DEBUG_MODE_QC
-        std::cout << "Updated initial layout: " << std::endl;
-        printPermutationMap(initialLayout, std::cout);
-#endif
-
         // remove potential output permutation entry
-        short output_qubit_index = -1;
-        auto  it                 = outputPermutation.find(physical_qubit_index);
+        dd::Qubit output_qubit_index = -1;
+        auto      it                 = outputPermutation.find(physical_qubit_index);
         if (it != outputPermutation.end()) {
-            output_qubit_index = static_cast<short>(it->second);
+            output_qubit_index = it->second;
             // erasing entry
             outputPermutation.erase(physical_qubit_index);
-#if DEBUG_MODE_QC
-            std::cout << "Updated output permutation: " << std::endl;
-            printPermutationMap(outputPermutation, std::cout);
-#endif
         }
 
         // update all operations
-        auto totalQubits = static_cast<unsigned short>(nqubits + nancillae);
+        auto totalQubits = static_cast<dd::QubitCount>(nqubits + nancillae);
         for (auto& op: ops) {
             op->setNqubits(totalQubits);
         }
 
         // update ancillary and garbage tracking
-        if (totalQubits < qc::MAX_QUBITS) {
-            for (unsigned short i = logical_qubit_index; i < totalQubits; ++i) {
-                ancillary[i] = ancillary[i + 1];
-                garbage[i]   = garbage[i + 1];
-            }
-            // unset last entry
-            ancillary.reset(totalQubits);
-            garbage.reset(totalQubits);
+        for (dd::QubitCount i = logical_qubit_index; i < totalQubits; ++i) {
+            ancillary[i] = ancillary[i + 1];
+            garbage[i]   = garbage[i + 1];
         }
+        // unset last entry
+        ancillary[totalQubits] = false;
+        garbage[totalQubits]   = false;
 
         return {physical_qubit_index, output_qubit_index};
     }
 
     // adds j-th physical qubit as ancilla to the end of reg or creates the register if necessary
-    void QuantumComputation::addAncillaryQubit(unsigned short physical_qubit_index, short output_qubit_index) {
+    void QuantumComputation::addAncillaryQubit(dd::Qubit physical_qubit_index, dd::Qubit output_qubit_index) {
         if (initialLayout.count(physical_qubit_index) || outputPermutation.count(physical_qubit_index)) {
             throw QFRException("[addAncillaryQubit] Attempting to insert physical qubit that is already assigned");
         }
-
-#if DEBUG_MODE_QC
-        std::cout << "Trying to add physical qubit " << physical_qubit_index
-                  << " as ancillary with output qubit index: " << output_qubit_index << std::endl;
-#endif
 
         bool fusionPossible = false;
         for (auto& ancreg: ancregs) {
@@ -411,32 +373,18 @@ namespace qc {
         }
 
         // index of logical qubit
-        unsigned short logical_qubit_index = nqubits + nancillae;
+        auto logical_qubit_index = static_cast<dd::Qubit>(nqubits + nancillae);
 
         // increase ancillae count and mark as ancillary
         nancillae++;
-        ancillary.set(logical_qubit_index);
-
-#if DEBUG_MODE_QC
-        std::cout << "Updated registers: " << std::endl;
-        printRegisters(std::cout);
-        std::cout << "nqubits: " << nqubits << ", nancillae: " << nancillae << std::endl;
-#endif
+        ancillary[logical_qubit_index] = true;
 
         // adjust initial layout
         initialLayout.insert({physical_qubit_index, logical_qubit_index});
-#if DEBUG_MODE_QC
-        std::cout << "Updated initial layout: " << std::endl;
-        printPermutationMap(initialLayout, std::cout);
-#endif
 
         // adjust output permutation
         if (output_qubit_index >= 0) {
             outputPermutation.insert({physical_qubit_index, output_qubit_index});
-#if DEBUG_MODE_QC
-            std::cout << "Updated output permutation: " << std::endl;
-            printPermutationMap(outputPermutation, std::cout);
-#endif
         }
 
         // update all operations
@@ -445,16 +393,15 @@ namespace qc {
         }
     }
 
-    void QuantumComputation::addQubit(unsigned short logical_qubit_index, unsigned short physical_qubit_index, short output_qubit_index) {
+    void QuantumComputation::addQubit(dd::Qubit logical_qubit_index, dd::Qubit physical_qubit_index, dd::Qubit output_qubit_index) {
         if (initialLayout.count(physical_qubit_index) || outputPermutation.count(physical_qubit_index)) {
-            std::cerr << "Attempting to insert physical qubit that is already assigned" << std::endl;
-            exit(1);
+            throw QFRException("[addQubit] Attempting to insert physical qubit that is already assigned");
         }
 
         if (logical_qubit_index > nqubits) {
-            std::cerr << "There are currently only " << nqubits << " qubits in the circuit. Adding "
-                      << logical_qubit_index << " is therefore not possible at the moment." << std::endl;
-            exit(1);
+            throw QFRException("[addQubit] There are currently only " + std::to_string(nqubits) +
+                               " qubits in the circuit. Adding " + std::to_string(logical_qubit_index) +
+                               " is therefore not possible at the moment.");
             // TODO: this does not necessarily have to lead to an error. A new qubit register could be created and all ancillaries shifted
         }
 
@@ -507,34 +454,31 @@ namespace qc {
         }
 
         // update ancillary and garbage tracking
-        for (unsigned short i = nqubits + nancillae - 1; i > logical_qubit_index; --i) {
+        for (auto i = static_cast<dd::Qubit>(nqubits + nancillae - 1); i > logical_qubit_index; --i) {
             ancillary[i] = ancillary[i - 1];
             garbage[i]   = garbage[i - 1];
         }
         // unset new entry
-        ancillary.reset(logical_qubit_index);
-        garbage.reset(logical_qubit_index);
+        ancillary[logical_qubit_index];
+        garbage[logical_qubit_index];
     }
 
-    dd::Edge QuantumComputation::createInitialMatrix(std::unique_ptr<dd::Package>& dd) const {
-        dd::Edge e = dd->makeIdent(nqubits + nancillae);
+    MatrixDD QuantumComputation::createInitialMatrix(std::unique_ptr<dd::Package>& dd) const {
+        auto e = dd->makeIdent(nqubits + nancillae);
         dd->incRef(e);
-        e = reduceAncillae(e, dd);
+        e = dd->reduceAncillae(e, ancillary);
         return e;
     }
 
-    dd::Edge QuantumComputation::buildFunctionality(std::unique_ptr<dd::Package>& dd) const {
+    MatrixDD QuantumComputation::buildFunctionality(std::unique_ptr<dd::Package>& dd) const {
         if (nqubits + nancillae == 0)
-            return dd->DDone;
+            return MatrixDD::one;
 
-        std::array<short, MAX_QUBITS> line{};
-        line.fill(LINE_DEFAULT);
-        permutationMap map = initialLayout;
-        dd->setMode(dd::Matrix);
-        dd::Edge e = createInitialMatrix(dd);
+        auto permutation = initialLayout;
+        auto e           = createInitialMatrix(dd);
 
         for (auto& op: ops) {
-            auto tmp = dd->multiply(op->getDD(dd, line, map), e);
+            auto tmp = dd->multiply(op->getDD(dd, permutation), e);
 
             dd->incRef(tmp);
             dd->decRef(e);
@@ -543,46 +487,44 @@ namespace qc {
             dd->garbageCollect();
         }
         // correct permutation if necessary
-        changePermutation(e, map, outputPermutation, line, dd);
-        e = reduceAncillae(e, dd);
+        changePermutation(e, permutation, outputPermutation, dd);
+        e = dd->reduceAncillae(e, ancillary);
+        e = dd->reduceGarbage(e, garbage);
 
         return e;
     }
 
-    dd::Edge QuantumComputation::buildFunctionalityRecursive(std::unique_ptr<dd::Package>& dd) const {
+    MatrixDD QuantumComputation::buildFunctionalityRecursive(std::unique_ptr<dd::Package>& dd) const {
         if (nqubits + nancillae == 0)
-            return dd->DDone;
+            return MatrixDD::one;
 
-        std::array<short, MAX_QUBITS> line{};
-        line.fill(LINE_DEFAULT);
-        permutationMap map = initialLayout;
-        dd->setMode(dd::Matrix);
+        auto permutation = initialLayout;
 
         if (ops.size() == 1) {
-            auto e = ops.front()->getDD(dd, line, map);
+            auto e = ops.front()->getDD(dd, permutation);
             dd->incRef(e);
             return e;
         }
 
-        std::stack<dd::Edge> s{};
-        auto                 depth = static_cast<unsigned int>(std::ceil(std::log2(ops.size())));
-        buildFunctionalityRecursive(depth, 0, s, line, map, dd);
+        std::stack<MatrixDD> s{};
+        auto                 depth = static_cast<std::size_t>(std::ceil(std::log2(ops.size())));
+        buildFunctionalityRecursive(depth, 0, s, permutation, dd);
         auto e = s.top();
         s.pop();
         return e;
     }
 
-    bool QuantumComputation::buildFunctionalityRecursive(unsigned int depth, size_t opIdx, std::stack<dd::Edge>& s, std::array<short, MAX_QUBITS>& line, permutationMap& map, std::unique_ptr<dd::Package>& dd) const {
+    bool QuantumComputation::buildFunctionalityRecursive(std::size_t depth, std::size_t opIdx, std::stack<MatrixDD>& s, Permutation& permutation, std::unique_ptr<dd::Package>& dd) const {
         // base case
         if (depth == 1) {
-            auto e = ops[opIdx]->getDD(dd, line, map);
+            auto e = ops[opIdx]->getDD(dd, permutation);
             ++opIdx;
             if (opIdx == ops.size()) { // only one element was left
                 s.push(e);
                 dd->incRef(e);
                 return false;
             }
-            auto f = ops[opIdx]->getDD(dd, line, map);
+            auto f = ops[opIdx]->getDD(dd, permutation);
             s.push(dd->multiply(f, e)); // ! reverse multiplication
             dd->incRef(s.top());
             return (opIdx != ops.size() - 1);
@@ -590,10 +532,10 @@ namespace qc {
 
         // in case no operations are left after the first recursive call nothing has to be done
         size_t leftIdx = opIdx & ~(1UL << (depth - 1));
-        if (!buildFunctionalityRecursive(depth - 1, leftIdx, s, line, map, dd)) return false;
+        if (!buildFunctionalityRecursive(depth - 1, leftIdx, s, permutation, dd)) return false;
 
         size_t rightIdx = opIdx | (1UL << (depth - 1));
-        auto   success  = buildFunctionalityRecursive(depth - 1, rightIdx, s, line, map, dd);
+        auto   success  = buildFunctionalityRecursive(depth - 1, rightIdx, s, permutation, dd);
 
         // get latest two results from stack and push their product on the stack
         auto e = s.top();
@@ -611,18 +553,14 @@ namespace qc {
         return success;
     }
 
-    dd::Edge QuantumComputation::simulate(const dd::Edge& in, std::unique_ptr<dd::Package>& dd) const {
+    VectorDD QuantumComputation::simulate(const VectorDD& in, std::unique_ptr<dd::Package>& dd) const {
         // measurements are currently not supported here
-        std::array<short, MAX_QUBITS> line{};
-        line.fill(LINE_DEFAULT);
-        permutationMap map = initialLayout;
-        dd->setMode(dd::Vector);
-        dd::Edge e = in;
+        auto permutation = initialLayout;
+        auto e           = in;
         dd->incRef(e);
 
         for (auto& op: ops) {
-            auto tmp = dd->multiply(op->getDD(dd, line, map), e);
-
+            auto tmp = dd->multiply(op->getDD(dd, permutation), e);
             dd->incRef(tmp);
             dd->decRef(e);
             e = tmp;
@@ -631,56 +569,21 @@ namespace qc {
         }
 
         // correct permutation if necessary
-        changePermutation(e, map, outputPermutation, line, dd);
-        e = reduceAncillae(e, dd);
+        changePermutation(e, permutation, outputPermutation, dd);
+        e = dd->reduceGarbage(e, garbage);
 
         return e;
-    }
-
-    void QuantumComputation::create_reg_array(const registerMap& regs, regnames_t& regnames, unsigned short defaultnumber, const char* defaultname) {
-        regnames.clear();
-
-        std::stringstream ss;
-        if (!regs.empty()) {
-            // sort regs by start index
-            std::map<unsigned short, std::pair<std::string, reg>> sortedRegs{};
-            for (const auto& reg: regs) {
-                sortedRegs.insert({reg.second.first, reg});
-            }
-
-            for (const auto& reg: sortedRegs) {
-                for (unsigned short i = 0; i < reg.second.second.second; i++) {
-                    ss << reg.second.first << "[" << i << "]";
-                    regnames.push_back(std::make_pair(reg.second.first, ss.str()));
-                    ss.str(std::string());
-                }
-            }
-        } else {
-            for (unsigned short i = 0; i < defaultnumber; i++) {
-                ss << defaultname << "[" << i << "]";
-                regnames.push_back(std::make_pair(defaultname, ss.str()));
-                ss.str(std::string());
-            }
-        }
     }
 
     std::ostream& QuantumComputation::print(std::ostream& os) const {
         os << std::setw((int)std::log10(ops.size()) + 1) << "i"
            << ": \t\t\t";
         for (const auto& Q: initialLayout) {
-            if (ancillary.test(Q.second))
-                os << "\033[31m" << Q.second << "\t\033[0m";
+            if (ancillary[Q.second])
+                os << "\033[31m" << static_cast<std::size_t>(Q.second) << "\t\033[0m";
             else
-                os << Q.second << "\t";
+                os << static_cast<std::size_t>(Q.second) << "\t";
         }
-        /*for (unsigned short i = 0; i < nqubits + nancillae; ++i) {
-			auto it = initialLayout.find(i);
-			if(it == initialLayout.end()) {
-				os << "|\t";
-			} else {
-				os << it->second << "\t";
-			}
-		}*/
         os << std::endl;
         size_t i = 0;
         for (const auto& op: ops) {
@@ -693,67 +596,28 @@ namespace qc {
         for (const auto& physical_qubit: initialLayout) {
             auto it = outputPermutation.find(physical_qubit.first);
             if (it == outputPermutation.end()) {
-                if (garbage.test(physical_qubit.second))
+                if (garbage[physical_qubit.second])
                     os << "\033[31m|\t\033[0m";
                 else
                     os << "|\t";
             } else {
-                os << it->second << "\t";
+                os << static_cast<std::size_t>(it->second) << "\t";
             }
         }
         os << std::endl;
         return os;
     }
 
-    dd::Complex QuantumComputation::getEntry(std::unique_ptr<dd::Package>& dd, dd::Edge e, unsigned long long i, unsigned long long j) const {
-        if (dd->isTerminal(e))
-            return e.w;
-
-        dd::Complex c = dd->cn.getTempCachedComplex(1, 0);
-        do {
-            unsigned short row = (i >> outputPermutation.at(e.p->v)) & 1u;
-            unsigned short col = (j >> initialLayout.at(e.p->v)) & 1u;
-            e                  = e.p->e[dd::RADIX * row + col];
-            CN::mul(c, c, e.w);
-        } while (!dd::Package::isTerminal(e));
-        return c;
-    }
-
-    std::ostream& QuantumComputation::printMatrix(std::unique_ptr<dd::Package>& dd, dd::Edge e, std::ostream& os) const {
-        os << "Common Factor: " << e.w << "\n";
-        for (unsigned long long i = 0; i < (1ull << (unsigned int)(nqubits + nancillae)); ++i) {
-            for (unsigned long long j = 0; j < (1ull << (unsigned int)(nqubits + nancillae)); ++j) {
-                os << std::right << std::setw(7) << std::setfill(' ') << getEntry(dd, e, i, j) << "\t";
-            }
-            os << std::endl;
-        }
-        return os;
-    }
-
-    void QuantumComputation::printBin(unsigned long long n, std::stringstream& ss) {
+    void QuantumComputation::printBin(std::size_t n, std::stringstream& ss) {
         if (n > 1)
             printBin(n / 2, ss);
         ss << n % 2;
     }
 
-    std::ostream& QuantumComputation::printCol(std::unique_ptr<dd::Package>& dd, dd::Edge e, unsigned long long j, std::ostream& os) const {
-        os << "Common Factor: " << e.w << "\n";
-        for (unsigned long long i = 0; i < (1ULL << static_cast<unsigned int>(nqubits + nancillae)); ++i) {
-            std::stringstream ss{};
-            printBin(i, ss);
-            os << std::setw(nqubits + nancillae) << ss.str() << ": " << getEntry(dd, e, i, j) << "\n";
-        }
-        return os;
-    }
-
-    std::ostream& QuantumComputation::printVector(std::unique_ptr<dd::Package>& dd, dd::Edge e, std::ostream& os) const {
-        return printCol(dd, e, 0, os);
-    }
-
     std::ostream& QuantumComputation::printStatistics(std::ostream& os) const {
         os << "QC Statistics:\n";
-        os << "\tn: " << nqubits << std::endl;
-        os << "\tanc: " << nancillae << std::endl;
+        os << "\tn: " << static_cast<std::size_t>(nqubits) << std::endl;
+        os << "\tanc: " << static_cast<std::size_t>(nancillae) << std::endl;
         os << "\tm: " << ops.size() << std::endl;
         os << "--------------" << std::endl;
         return os;
@@ -778,67 +642,34 @@ namespace qc {
         }
     }
 
-    void QuantumComputation::consolidateRegister(registerMap& regs) {
-        bool finished = false;
-        while (!finished) {
-            for (const auto& qreg: regs) {
-                finished     = true;
-                auto regname = qreg.first;
-                // check if lower part of register
-                if (regname.length() > 2 && regname.compare(regname.size() - 2, 2, "_l") == 0) {
-                    auto lowidx = qreg.second.first;
-                    auto lownum = qreg.second.second;
-                    // search for higher part of register
-                    auto highname = regname.substr(0, regname.size() - 1) + 'h';
-                    auto it       = regs.find(highname);
-                    if (it != regs.end()) {
-                        auto highidx = it->second.first;
-                        auto highnum = it->second.second;
-                        // fusion of registers possible
-                        if (lowidx + lownum == highidx) {
-                            finished        = false;
-                            auto targetname = regname.substr(0, regname.size() - 2);
-                            auto targetidx  = lowidx;
-                            auto targetnum  = lownum + highnum;
-                            regs.insert({targetname, {targetidx, targetnum}});
-                            regs.erase(regname);
-                            regs.erase(highname);
-                        }
-                    }
-                    break;
-                }
-            }
-        }
-    }
-
     void QuantumComputation::dumpOpenQASM(std::ostream& of) {
         // Add missing physical qubits
         if (!qregs.empty()) {
-            for (unsigned short physical_qubit = 0; physical_qubit < initialLayout.rbegin()->first; ++physical_qubit) {
-                if (!initialLayout.count(physical_qubit)) {
-                    auto logicalQubit = getHighestLogicalQubitIndex() + 1;
-                    addQubit(logicalQubit, physical_qubit, -1);
+            for (dd::QubitCount physical_qubit = 0; physical_qubit < initialLayout.rbegin()->first; ++physical_qubit) {
+                if (!initialLayout.count(static_cast<dd::Qubit>(physical_qubit))) {
+                    auto logicalQubit = static_cast<dd::Qubit>(getHighestLogicalQubitIndex() + 1);
+                    addQubit(logicalQubit, static_cast<dd::Qubit>(physical_qubit), -1);
                 }
             }
         }
 
         // dump initial layout and output permutation
-        permutationMap inverseInitialLayout{};
+        Permutation inverseInitialLayout{};
         for (const auto& q: initialLayout)
             inverseInitialLayout.insert({q.second, q.first});
         of << "// i";
         for (const auto& q: inverseInitialLayout) {
-            of << " " << q.second;
+            of << " " << static_cast<std::size_t>(q.second);
         }
         of << std::endl;
 
-        permutationMap inverseOutputPermutation{};
+        Permutation inverseOutputPermutation{};
         for (const auto& q: outputPermutation) {
             inverseOutputPermutation.insert({q.second, q.first});
         }
         of << "// o";
         for (const auto& q: inverseOutputPermutation) {
-            of << " " << q.second;
+            of << " " << static_cast<std::size_t>(q.second);
         }
         of << std::endl;
 
@@ -847,7 +678,7 @@ namespace qc {
         if (!qregs.empty()) {
             printSortedRegisters(qregs, "qreg", of);
         } else if (nqubits > 0) {
-            of << "qreg " << DEFAULT_QREG << "[" << nqubits << "];" << std::endl;
+            of << "qreg " << DEFAULT_QREG << "[" << static_cast<std::size_t>(nqubits) << "];" << std::endl;
         }
         if (!cregs.empty()) {
             printSortedRegisters(cregs, "creg", of);
@@ -857,33 +688,21 @@ namespace qc {
         if (!ancregs.empty()) {
             printSortedRegisters(ancregs, "qreg", of);
         } else if (nancillae > 0) {
-            of << "qreg " << DEFAULT_ANCREG << "[" << nancillae << "];" << std::endl;
+            of << "qreg " << DEFAULT_ANCREG << "[" << static_cast<std::size_t>(nancillae) << "];" << std::endl;
         }
 
-        regnames_t qregnames{};
-        regnames_t cregnames{};
-        regnames_t ancregnames{};
-        create_reg_array(qregs, qregnames, nqubits, DEFAULT_QREG);
-        create_reg_array(cregs, cregnames, nclassics, DEFAULT_CREG);
-        create_reg_array(ancregs, ancregnames, nancillae, DEFAULT_ANCREG);
+        RegisterNames qregnames{};
+        RegisterNames cregnames{};
+        RegisterNames ancregnames{};
+        createRegisterArray(qregs, qregnames, nqubits, DEFAULT_QREG);
+        createRegisterArray(cregs, cregnames, nclassics, DEFAULT_CREG);
+        createRegisterArray(ancregs, ancregnames, nancillae, DEFAULT_ANCREG);
 
         for (const auto& ancregname: ancregnames)
             qregnames.push_back(ancregname);
 
         for (const auto& op: ops) {
             op->dumpOpenQASM(of, qregnames, cregnames);
-        }
-    }
-
-    void QuantumComputation::printSortedRegisters(const registerMap& regmap, const std::string& identifier, std::ostream& of) {
-        // sort regs by start index
-        std::map<unsigned short, std::pair<std::string, reg>> sortedRegs{};
-        for (const auto& reg: regmap) {
-            sortedRegs.insert({reg.second.first, reg});
-        }
-
-        for (const auto& reg: sortedRegs) {
-            of << identifier << " " << reg.second.first << "[" << reg.second.second.second << "];" << std::endl;
         }
     }
 
@@ -914,7 +733,7 @@ namespace qc {
                 break;
             case Qiskit:
                 // TODO: improve/modernize Qiskit dump
-                unsigned short totalQubits = nqubits + nancillae + (max_controls >= 2 ? max_controls - 2 : 0);
+                dd::QubitCount totalQubits = nqubits + nancillae + (max_controls >= 2 ? max_controls - 2 : 0);
                 if (totalQubits > 53) {
                     std::cerr << "No more than 53 total qubits are currently supported" << std::endl;
                     break;
@@ -924,7 +743,7 @@ namespace qc {
                 // This may be adapted in the future
                 of << "from qiskit import *" << std::endl;
                 of << "from qiskit.test.mock import ";
-                unsigned short narchitecture = 0;
+                dd::QubitCount narchitecture = 0;
                 if (totalQubits <= 5) {
                     of << "FakeBurlington";
                     narchitecture = 5;
@@ -941,15 +760,15 @@ namespace qc {
                 of << "from math import pi" << std::endl
                    << std::endl;
 
-                of << DEFAULT_QREG << " = QuantumRegister(" << nqubits << ", '" << DEFAULT_QREG << "')" << std::endl;
+                of << DEFAULT_QREG << " = QuantumRegister(" << static_cast<std::size_t>(nqubits) << ", '" << DEFAULT_QREG << "')" << std::endl;
                 if (nclassics > 0) {
                     of << DEFAULT_CREG << " = ClassicalRegister(" << nclassics << ", '" << DEFAULT_CREG << "')" << std::endl;
                 }
                 if (nancillae > 0) {
-                    of << DEFAULT_ANCREG << " = QuantumRegister(" << nancillae << ", '" << DEFAULT_ANCREG << "')" << std::endl;
+                    of << DEFAULT_ANCREG << " = QuantumRegister(" << static_cast<std::size_t>(nancillae) << ", '" << DEFAULT_ANCREG << "')" << std::endl;
                 }
                 if (max_controls > 2) {
-                    of << DEFAULT_MCTREG << " = QuantumRegister(" << max_controls - 2 << ", '" << DEFAULT_MCTREG << "')" << std::endl;
+                    of << DEFAULT_MCTREG << " = QuantumRegister(" << static_cast<std::size_t>(max_controls - 2) << ", '" << DEFAULT_MCTREG << "')" << std::endl;
                 }
                 of << "qc = QuantumCircuit(";
                 of << DEFAULT_QREG;
@@ -965,12 +784,12 @@ namespace qc {
                 of << ")" << std::endl
                    << std::endl;
 
-                regnames_t qregnames{};
-                regnames_t cregnames{};
-                regnames_t ancregnames{};
-                create_reg_array({}, qregnames, nqubits, DEFAULT_QREG);
-                create_reg_array({}, cregnames, nclassics, DEFAULT_CREG);
-                create_reg_array({}, ancregnames, nancillae, DEFAULT_ANCREG);
+                RegisterNames qregnames{};
+                RegisterNames cregnames{};
+                RegisterNames ancregnames{};
+                createRegisterArray<QuantumRegister>({}, qregnames, nqubits, DEFAULT_QREG);
+                createRegisterArray<ClassicalRegister>({}, cregnames, nclassics, DEFAULT_CREG);
+                createRegisterArray<QuantumRegister>({}, ancregnames, nancillae, DEFAULT_ANCREG);
 
                 for (const auto& ancregname: ancregnames)
                     qregnames.push_back(ancregname);
@@ -1030,12 +849,8 @@ namespace qc {
         }
     }
 
-    bool QuantumComputation::isIdleQubit(unsigned short physical_qubit) const {
-        for (const auto& op: ops) {
-            if (op->actsOn(physical_qubit))
-                return false;
-        }
-        return true;
+    bool QuantumComputation::isIdleQubit(dd::Qubit physical_qubit) const {
+        return !std::any_of(ops.cbegin(), ops.cend(), [&physical_qubit](const auto& op) { return op->actsOn(physical_qubit); });
     }
 
     void QuantumComputation::stripIdleQubits(bool force, bool reduceIOpermutations) {
@@ -1045,23 +860,14 @@ namespace qc {
             if (isIdleQubit(physical_qubit_index)) {
                 auto it = outputPermutation.find(physical_qubit_index);
                 if (it != outputPermutation.end()) {
-                    auto output_index = static_cast<short>(it->second);
+                    auto output_index = it->second;
                     if (!force && output_index >= 0) continue;
                 }
 
-                unsigned short logical_qubit_index = initialLayout.at(physical_qubit_index);
-#if DEBUG_MODE_QC
-                std::cout << "Trying to strip away idle qubit: " << physical_qubit_index
-                          << ", which corresponds to logical qubit: " << logical_qubit_index << std::endl;
-                print(std::cout);
-#endif
+                auto logical_qubit_index = initialLayout.at(physical_qubit_index);
                 removeQubit(logical_qubit_index);
 
                 if (reduceIOpermutations && (logical_qubit_index < nqubits + nancillae)) {
-#if DEBUG_MODE_QC
-                    std::cout << "Qubit " << logical_qubit_index << " is inner qubit. Need to adjust permutations." << std::endl;
-#endif
-
                     for (auto& q: initialLayout) {
                         if (q.second > logical_qubit_index)
                             q.second--;
@@ -1071,19 +877,7 @@ namespace qc {
                         if (q.second > logical_qubit_index)
                             q.second--;
                     }
-
-#if DEBUG_MODE_QC
-                    std::cout << "Changed initial layout" << std::endl;
-                    printPermutationMap(initialLayout);
-                    std::cout << "Changed output permutation" << std::endl;
-                    printPermutationMap(outputPermutation);
-#endif
                 }
-
-#if DEBUG_MODE_QC
-                std::cout << "Resulting in: " << std::endl;
-                print(std::cout);
-#endif
             }
         }
         for (auto& op: ops) {
@@ -1091,84 +885,17 @@ namespace qc {
         }
     }
 
-    void QuantumComputation::changePermutation(dd::Edge& on, qc::permutationMap& from, const qc::permutationMap& to, std::array<short, qc::MAX_QUBITS>& line, std::unique_ptr<dd::Package>& dd, bool regular) {
-        assert(from.size() >= to.size());
-
-#if DEBUG_MODE_QC
-        std::cout << "Trying to change: " << std::endl;
-        printPermutationMap(from);
-        std::cout << "to: " << std::endl;
-        printPermutationMap(to);
-#endif
-
-        auto n = static_cast<short>(on.p->v + 1);
-
-        // iterate over (k,v) pairs of second permutation
-        for (const auto& kv: to) {
-            unsigned short i    = kv.first;
-            unsigned short goal = kv.second;
-
-            // search for key in the first map
-            auto it = from.find(i);
-            if (it == from.end()) {
-                throw QFRException("[changePermutation] Key " + std::to_string(it->first) + " was not found in first permutation. This should never happen.");
-            }
-            unsigned short current = it->second;
-
-            // permutations agree for this key value
-            if (current == goal) continue;
-
-            // search for goal value in first permutation
-            unsigned short j = 0;
-            for (const auto& pair: from) {
-                unsigned short value = pair.second;
-                if (value == goal) {
-                    j = pair.first;
-                    break;
-                }
-            }
-
-            // swap i and j
-            auto op = qc::StandardOperation(n, {i, j}, qc::SWAP);
-
-#if DEBUG_MODE_QC
-            std::cout << "Apply SWAP: " << i << " " << j << std::endl;
-#endif
-
-            op.setLine(line, from);
-            auto saved = on;
-            if (regular) {
-                on = dd->multiply(op.getSWAPDD(dd, line, from), on);
-            } else {
-                on = dd->multiply(on, op.getSWAPDD(dd, line, from));
-            }
-            op.resetLine(line, from);
-            dd->incRef(on);
-            dd->decRef(saved);
-            dd->garbageCollect();
-
-            // update permutation
-            from.at(i) = goal;
-            from.at(j) = current;
-
-#if DEBUG_MODE_QC
-            std::cout << "Changed permutation" << std::endl;
-            printPermutationMap(from);
-#endif
-        }
-    }
-
-    std::string QuantumComputation::getQubitRegister(unsigned short physical_qubit_index) const {
+    std::string QuantumComputation::getQubitRegister(dd::Qubit physical_qubit_index) const {
         for (const auto& reg: qregs) {
-            unsigned short start_idx = reg.second.first;
-            unsigned short count     = reg.second.second;
+            auto start_idx = reg.second.first;
+            auto count     = reg.second.second;
             if (physical_qubit_index < start_idx) continue;
             if (physical_qubit_index >= start_idx + count) continue;
             return reg.first;
         }
         for (const auto& reg: ancregs) {
-            unsigned short start_idx = reg.second.first;
-            unsigned short count     = reg.second.second;
+            auto start_idx = reg.second.first;
+            auto count     = reg.second.second;
             if (physical_qubit_index < start_idx) continue;
             if (physical_qubit_index >= start_idx + count) continue;
             return reg.first;
@@ -1177,26 +904,26 @@ namespace qc {
         throw QFRException("[getQubitRegister] Qubit index " + std::to_string(physical_qubit_index) + " not found in any register");
     }
 
-    std::pair<std::string, unsigned short> QuantumComputation::getQubitRegisterAndIndex(unsigned short physical_qubit_index) const {
-        std::string    reg_name = getQubitRegister(physical_qubit_index);
-        unsigned short index    = 0;
-        auto           it       = qregs.find(reg_name);
+    std::pair<std::string, dd::Qubit> QuantumComputation::getQubitRegisterAndIndex(dd::Qubit physical_qubit_index) const {
+        std::string reg_name = getQubitRegister(physical_qubit_index);
+        dd::Qubit   index    = 0;
+        auto        it       = qregs.find(reg_name);
         if (it != qregs.end()) {
-            index = physical_qubit_index - it->second.first;
+            index = static_cast<dd::Qubit>(physical_qubit_index - it->second.first);
         } else {
             auto it_anc = ancregs.find(reg_name);
             if (it_anc != ancregs.end()) {
-                index = physical_qubit_index - it_anc->second.first;
+                index = static_cast<dd::Qubit>(physical_qubit_index - it_anc->second.first);
             }
             // no else branch needed here, since error would have already shown in getQubitRegister(physical_qubit_index)
         }
         return {reg_name, index};
     }
 
-    std::string QuantumComputation::getClassicalRegister(unsigned short classical_index) const {
+    std::string QuantumComputation::getClassicalRegister(std::size_t classical_index) const {
         for (const auto& reg: cregs) {
-            unsigned short start_idx = reg.second.first;
-            unsigned short count     = reg.second.second;
+            auto start_idx = reg.second.first;
+            auto count     = reg.second.second;
             if (classical_index < start_idx) continue;
             if (classical_index >= start_idx + count) continue;
             return reg.first;
@@ -1205,28 +932,28 @@ namespace qc {
         throw QFRException("[getClassicalRegister] Classical index " + std::to_string(classical_index) + " not found in any register");
     }
 
-    std::pair<std::string, unsigned short> QuantumComputation::getClassicalRegisterAndIndex(unsigned short classical_index) const {
-        std::string    reg_name = getClassicalRegister(classical_index);
-        unsigned short index    = 0;
-        auto           it       = cregs.find(reg_name);
+    std::pair<std::string, std::size_t> QuantumComputation::getClassicalRegisterAndIndex(std::size_t classical_index) const {
+        std::string reg_name = getClassicalRegister(classical_index);
+        std::size_t index    = 0;
+        auto        it       = cregs.find(reg_name);
         if (it != cregs.end()) {
             index = classical_index - it->second.first;
         } // else branch not needed since getClassicalRegister already covers this case
         return {reg_name, index};
     }
 
-    unsigned short QuantumComputation::getIndexFromQubitRegister(const std::pair<std::string, unsigned short>& qubit) const {
+    dd::Qubit QuantumComputation::getIndexFromQubitRegister(const std::pair<std::string, dd::Qubit>& qubit) const {
         // no range check is performed here!
-        return static_cast<unsigned short>(qregs.at(qubit.first).first + qubit.second);
+        return static_cast<dd::Qubit>(qregs.at(qubit.first).first + qubit.second);
     }
-    unsigned short QuantumComputation::getIndexFromClassicalRegister(const std::pair<std::string, unsigned short>& clbit) const {
+    std::size_t QuantumComputation::getIndexFromClassicalRegister(const std::pair<std::string, std::size_t>& clbit) const {
         // no range check is performed here!
-        return static_cast<unsigned short>(cregs.at(clbit.first).first + clbit.second);
+        return static_cast<std::size_t>(cregs.at(clbit.first).first + clbit.second);
     }
 
-    std::ostream& QuantumComputation::printPermutationMap(const permutationMap& map, std::ostream& os) {
-        for (const auto& Q: map) {
-            os << "\t" << Q.first << ": " << Q.second << std::endl;
+    std::ostream& QuantumComputation::printPermutation(const Permutation& permutation, std::ostream& os) {
+        for (const auto& Q: permutation) {
+            os << "\t" << static_cast<std::size_t>(Q.first) << ": " << static_cast<std::size_t>(Q.second) << std::endl;
         }
         return os;
     }
@@ -1234,13 +961,13 @@ namespace qc {
     std::ostream& QuantumComputation::printRegisters(std::ostream& os) const {
         os << "qregs:";
         for (const auto& qreg: qregs) {
-            os << " {" << qreg.first << ", {" << qreg.second.first << ", " << qreg.second.second << "}}";
+            os << " {" << qreg.first << ", {" << static_cast<std::size_t>(qreg.second.first) << ", " << static_cast<std::size_t>(qreg.second.second) << "}}";
         }
         os << std::endl;
         if (!ancregs.empty()) {
             os << "ancregs:";
             for (const auto& ancreg: ancregs) {
-                os << " {" << ancreg.first << ", {" << ancreg.second.first << ", " << ancreg.second.second << "}}";
+                os << " {" << ancreg.first << ", {" << static_cast<std::size_t>(ancreg.second.first) << ", " << static_cast<std::size_t>(ancreg.second.second) << "}}";
             }
             os << std::endl;
         }
@@ -1252,37 +979,35 @@ namespace qc {
         return os;
     }
 
-    unsigned short QuantumComputation::getHighestLogicalQubitIndex(const permutationMap& map) {
-        unsigned short max_index = 0;
-        for (const auto& physical_qubit: map) {
-            if (physical_qubit.second > max_index) {
-                max_index = physical_qubit.second;
-            }
+    dd::Qubit QuantumComputation::getHighestLogicalQubitIndex(const Permutation& permutation) {
+        dd::Qubit max_index = 0;
+        for (const auto& physical_qubit: permutation) {
+            max_index = std::max(max_index, physical_qubit.second);
         }
         return max_index;
     }
 
-    bool QuantumComputation::physicalQubitIsAncillary(unsigned short physical_qubit_index) const {
-        return std::any_of(ancregs.cbegin(), ancregs.cend(), [&physical_qubit_index](const registerMap::value_type& ancreg) { return ancreg.second.first <= physical_qubit_index && physical_qubit_index < ancreg.second.first + ancreg.second.second; });
+    bool QuantumComputation::physicalQubitIsAncillary(dd::Qubit physical_qubit_index) const {
+        return std::any_of(ancregs.cbegin(), ancregs.cend(), [&physical_qubit_index](const auto& ancreg) { return ancreg.second.first <= physical_qubit_index && physical_qubit_index < ancreg.second.first + ancreg.second.second; });
     }
 
-    bool QuantumComputation::isLastOperationOnQubit(const decltype(ops.begin())& opIt, const decltype(ops.cend())& end) {
+    bool QuantumComputation::isLastOperationOnQubit(const decltype(ops.cbegin())& opIt, const decltype(ops.cend())& end) const {
         if (opIt == end)
             return true;
 
         // determine which qubits the gate acts on
-        std::bitset<MAX_QUBITS> actson{};
-        for (unsigned short i = 0; i < MAX_QUBITS; ++i) {
-            if ((*opIt)->actsOn(i))
-                actson.set(i);
+        std::vector<bool> actson(nqubits + nancillae);
+        for (std::size_t i = 0; i < actson.size(); ++i) {
+            if ((*opIt)->actsOn(static_cast<dd::Qubit>(i)))
+                actson[i] = true;
         }
 
         // iterate over remaining gates and check if any act on qubits overlapping with the target gate
         auto atEnd = opIt;
         std::advance(atEnd, 1);
         while (atEnd != end) {
-            for (unsigned short i = 0; i < MAX_QUBITS; ++i) {
-                if (actson[i] && (*atEnd)->actsOn(i)) return false;
+            for (std::size_t i = 0; i < actson.size(); ++i) {
+                if (actson[i] && (*atEnd)->actsOn(static_cast<dd::Qubit>(i))) return false;
             }
             ++atEnd;
         }

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -576,8 +576,11 @@ namespace qc {
     }
 
     std::ostream& QuantumComputation::print(std::ostream& os) const {
-        os << std::setw((int)std::log10(ops.size()) + 1) << "i"
-           << ": \t\t\t";
+        if (!ops.empty()) {
+            os << std::setw((int)std::log10(ops.size()) + 1) << "i: \t\t\t";
+        } else {
+            os << "i: \t\t\t";
+        }
         for (const auto& Q: initialLayout) {
             if (ancillary[Q.second])
                 os << "\033[31m" << static_cast<std::size_t>(Q.second) << "\t\033[0m";
@@ -591,8 +594,11 @@ namespace qc {
             op->print(os, initialLayout);
             os << std::endl;
         }
-        os << std::setw((int)std::log10(ops.size()) + 1) << "o"
-           << ": \t\t\t";
+        if (!ops.empty()) {
+            os << std::setw((int) std::log10(ops.size()) + 1) << "o: \t\t\t";
+        } else {
+            os << "o: \t\t\t";
+        }
         for (const auto& physical_qubit: initialLayout) {
             auto it = outputPermutation.find(physical_qubit.first);
             if (it == outputPermutation.end()) {

--- a/src/algorithms/BernsteinVazirani.cpp
+++ b/src/algorithms/BernsteinVazirani.cpp
@@ -11,12 +11,12 @@ namespace qc {
 	 * Private Methods
 	 ***/
     void BernsteinVazirani::setup() {
-        for (unsigned short i = 0; i < nqubits; ++i)
+        for (dd::QubitCount i = 0; i < nqubits; ++i)
             emplace_back<StandardOperation>(nqubits, i, H);
     }
 
     void BernsteinVazirani::oracle() {
-        for (unsigned short i = 0; i < nqubits; ++i) {
+        for (dd::QubitCount i = 0; i < nqubits; ++i) {
             if (((hiddenInteger >> i) & 1) == 1) {
                 emplace_back<StandardOperation>(nqubits, i, Z);
             }
@@ -24,7 +24,7 @@ namespace qc {
     }
 
     void BernsteinVazirani::postProcessing() {
-        for (unsigned short i = 0; i < nqubits; ++i)
+        for (dd::QubitCount i = 0; i < nqubits; ++i)
             emplace_back<StandardOperation>(nqubits, i, H);
     }
 
@@ -38,15 +38,13 @@ namespace qc {
     /***
 	 * Public Methods
 	 ***/
-    BernsteinVazirani::BernsteinVazirani(unsigned long hiddenInteger):
+    BernsteinVazirani::BernsteinVazirani(std::size_t hiddenInteger):
         hiddenInteger(hiddenInteger) {
         name = "bv_" + std::to_string(hiddenInteger);
-        // Determine the bitsize of the hidden integer
-        while (hiddenInteger >> ++(size) > 0)
-            ;
 
-        // Prevents a circuit with 0 qubits
-        if (size == 0) {
+        if (hiddenInteger > 0) {
+            size = static_cast<dd::QubitCount>(std::ceil(std::log2(hiddenInteger)));
+        } else {
             size = 1;
         }
 
@@ -59,8 +57,8 @@ namespace qc {
     }
 
     std::ostream& BernsteinVazirani::printStatistics(std::ostream& os) const {
-        os << "BernsteinVazirani (" << nqubits << ") Statistics:\n";
-        os << "\tn: " << nqubits + 1 << std::endl;
+        os << "BernsteinVazirani (" << static_cast<std::size_t>(nqubits) << ") Statistics:\n";
+        os << "\tn: " << static_cast<std::size_t>(nqubits + 1) << std::endl;
         os << "\tm: " << getNindividualOps() << std::endl;
         os << "\tHiddenInteger: " << hiddenInteger << std::endl;
         os << "--------------" << std::endl;

--- a/src/algorithms/Entanglement.cpp
+++ b/src/algorithms/Entanglement.cpp
@@ -6,13 +6,13 @@
 #include "algorithms/Entanglement.hpp"
 
 namespace qc {
-    Entanglement::Entanglement(unsigned short nq):
+    Entanglement::Entanglement(dd::QubitCount nq):
         QuantumComputation(nq) {
         name = "entanglement_" + std::to_string(nq);
         emplace_back<StandardOperation>(nqubits, 0, H);
 
         for (unsigned short i = 1; i < nq; i++) {
-            emplace_back<StandardOperation>(nqubits, Control(0, Control::pos), i, X);
+            emplace_back<StandardOperation>(nqubits, dd::Control{0}, i, X);
         }
     }
 } // namespace qc

--- a/src/algorithms/Grover.cpp
+++ b/src/algorithms/Grover.cpp
@@ -130,7 +130,6 @@ namespace qc {
         e = dd->reduceGarbage(e, garbage);
 
         dd->decRef(iteration);
-        dd->garbageCollect(true);
         return e;
     }
 
@@ -164,6 +163,7 @@ namespace qc {
             f = tmp;
             if (iterBits[j]) {
                 if (zero) {
+                    dd->decRef(e);
                     e = f;
                     dd->incRef(e);
                     zero = false;
@@ -176,6 +176,7 @@ namespace qc {
                 }
             }
         }
+        dd->decRef(f);
 
         // apply state preparation setup
         qc::QuantumComputation statePrep(nqubits + 1);
@@ -183,6 +184,7 @@ namespace qc {
         auto s   = statePrep.buildFunctionality(dd);
         auto tmp = dd->multiply(e, s);
         dd->incRef(tmp);
+        dd->decRef(s);
         dd->decRef(e);
         e = tmp;
 

--- a/src/algorithms/Grover.cpp
+++ b/src/algorithms/Grover.cpp
@@ -11,46 +11,46 @@ namespace qc {
      ***/
     void Grover::setup(QuantumComputation& qc) const {
         qc.emplace_back<StandardOperation>(nqubits + nancillae, nqubits, X);
-        for (unsigned short i = 0; i < nqubits; ++i)
+        for (dd::QubitCount i = 0; i < nqubits; ++i)
             qc.emplace_back<StandardOperation>(nqubits + nancillae, i, H);
     }
 
     void Grover::oracle(QuantumComputation& qc) const {
         const std::bitset<64> xBits(x);
-        std::vector<Control>  controls{};
-        for (unsigned short i = 0; i < nqubits; ++i) {
-            controls.emplace_back(i, xBits[i] ? Control::pos : Control::neg);
+        dd::Controls          controls{};
+        for (dd::QubitCount i = 0; i < nqubits; ++i) {
+            controls.emplace(dd::Control{static_cast<dd::Qubit>(i), xBits[i] ? dd::Control::Type::pos : dd::Control::Type::neg});
         }
-        unsigned short target = nqubits;
+        auto target = static_cast<dd::Qubit>(nqubits);
         qc.emplace_back<StandardOperation>(nqubits + nancillae, controls, target, qc::Z);
     }
 
     void Grover::diffusion(QuantumComputation& qc) const {
         //std::vector<unsigned short> targets{};
-        for (unsigned short i = 0; i < nqubits; ++i) {
+        for (dd::QubitCount i = 0; i < nqubits; ++i) {
             //targets.push_back(i);
             qc.emplace_back<StandardOperation>(nqubits + nancillae, i, H);
         }
-        for (unsigned short i = 0; i < nqubits; ++i) {
+        for (dd::QubitCount i = 0; i < nqubits; ++i) {
             qc.emplace_back<StandardOperation>(nqubits + nancillae, i, X);
         }
 
         //qc.emplace_back<StandardOperation>(nqubits+nancillae, targets, H);
         //qc.emplace_back<StandardOperation>(nqubits+nancillae, targets, X);
 
-        auto target = static_cast<unsigned short>(std::max(nqubits - 1, 0));
+        auto target = static_cast<dd::Qubit>(std::max(nqubits - 1, 0));
         qc.emplace_back<StandardOperation>(nqubits + nancillae, target, H);
-        std::vector<Control> controls{};
-        for (unsigned short j = 0; j < nqubits - 1; ++j) {
-            controls.emplace_back(j);
+        dd::Controls controls{};
+        for (dd::Qubit j = 0; j < nqubits - 1; ++j) {
+            controls.emplace(dd::Control{j});
         }
         qc.emplace_back<StandardOperation>(nqubits + nancillae, controls, target);
         qc.emplace_back<StandardOperation>(nqubits + nancillae, target, H);
 
-        for (auto i = static_cast<short>(nqubits - 1); i >= 0; --i) {
+        for (auto i = static_cast<dd::Qubit>(nqubits - 1); i >= 0; --i) {
             qc.emplace_back<StandardOperation>(nqubits + nancillae, i, X);
         }
-        for (auto i = static_cast<short>(nqubits - 1); i >= 0; --i) {
+        for (auto i = static_cast<dd::Qubit>(nqubits - 1); i >= 0; --i) {
             qc.emplace_back<StandardOperation>(nqubits + nancillae, i, H);
         }
 
@@ -62,7 +62,7 @@ namespace qc {
         // Generate circuit
         setup(qc);
 
-        for (unsigned long long j = 0; j < iterations; ++j) {
+        for (std::size_t j = 0; j < iterations; ++j) {
             oracle(qc);
             diffusion(qc);
         }
@@ -73,7 +73,7 @@ namespace qc {
     /***
      * Public Methods
      ***/
-    Grover::Grover(unsigned short nq, unsigned int seed):
+    Grover::Grover(dd::QubitCount nq, std::size_t seed):
         seed(seed) {
         name = "grover_" + std::to_string(nq);
 
@@ -81,39 +81,35 @@ namespace qc {
         addAncillaryRegister(1);
         addClassicalRegister(nq + 1);
 
-        line.fill(LINE_DEFAULT);
-
-        std::mt19937_64                                   generator(this->seed);
-        std::uniform_int_distribution<unsigned long long> distribution(0, static_cast<unsigned long long>(std::pow(2.L, std::max(static_cast<unsigned short>(0), nqubits)) - 1.));
+        std::mt19937_64                            generator(this->seed);
+        std::uniform_int_distribution<std::size_t> distribution(0, static_cast<std::size_t>(std::pow(2.L, std::max(static_cast<dd::QubitCount>(0), nqubits)) - 1.));
         oracleGenerator = [&]() { return distribution(generator); };
         x               = oracleGenerator();
 
         if (nqubits <= 3) {
             iterations = 1;
         } else if (nqubits % 2 == 0) {
-            iterations = static_cast<unsigned long long>(std::round(PI_4 * std::pow(2.L, (nqubits + 1.) / 2.L - 1.) * std::sqrt(2)));
+            iterations = static_cast<std::size_t>(std::round(dd::PI_4 * std::pow(2.L, (nqubits + 1.) / 2.L - 1.) * std::sqrt(2)));
         } else {
-            iterations = static_cast<unsigned long long>(std::round(PI_4 * std::pow(2.L, (nqubits) / 2.L)));
+            iterations = static_cast<std::size_t>(std::round(dd::PI_4 * std::pow(2.L, (nqubits) / 2.L)));
         }
 
         full_grover(*this);
-        setLogicalQubitGarbage(nqubits);
+        setLogicalQubitGarbage(static_cast<dd::Qubit>(nqubits));
     }
 
-    dd::Edge Grover::buildFunctionality(std::unique_ptr<dd::Package>& dd) const {
-        dd->setMode(dd::Matrix);
-
+    MatrixDD Grover::buildFunctionality(std::unique_ptr<dd::Package>& dd) const {
         QuantumComputation groverIteration(nqubits + 1);
         oracle(groverIteration);
         diffusion(groverIteration);
 
-        dd::Edge iteration = groverIteration.buildFunctionality(dd);
+        auto iteration = groverIteration.buildFunctionality(dd);
 
-        dd::Edge e = iteration;
+        auto e = iteration;
         dd->incRef(e);
 
-        for (unsigned long long i = 0; i < iterations - 1; ++i) {
-            dd::Edge f = dd->multiply(iteration, e);
+        for (std::size_t i = 0; i < iterations - 1; ++i) {
+            auto f = dd->multiply(iteration, e);
             dd->decRef(e);
             e = f;
             dd->incRef(e);
@@ -122,36 +118,25 @@ namespace qc {
 
         QuantumComputation qc(nqubits + nancillae);
         setup(qc);
-        auto     g = qc.buildFunctionality(dd);
-        dd::Edge f = dd->multiply(e, g);
+        auto g = qc.buildFunctionality(dd);
+        auto f = dd->multiply(e, g);
         dd->decRef(e);
         dd->decRef(g);
         dd->incRef(f);
         e = f;
 
         // properly handle ancillary qubit
-        e = reduceAncillae(e, dd);
-        e = reduceGarbage(e, dd);
+        e = dd->reduceAncillae(e, ancillary);
+        e = dd->reduceGarbage(e, garbage);
 
         dd->decRef(iteration);
         dd->garbageCollect(true);
         return e;
     }
 
-    dd::Edge Grover::simulate(const dd::Edge& in, std::unique_ptr<dd::Package>& dd) const {
-        //TODO: Enhance this simulation routine // delegate to simulator
-
-        // initial state too small
-        dd::Edge initialState = in;
-        if (in.p->v == nqubits - 1) {
-            initialState = dd->extend(in, 1);
-        }
-        return QuantumComputation::simulate(initialState, dd);
-    }
-
     std::ostream& Grover::printStatistics(std::ostream& os) const {
-        os << "Grover (" << nqubits << ") Statistics:\n";
-        os << "\tn: " << nqubits + 1 << std::endl;
+        os << "Grover (" << static_cast<std::size_t>(nqubits) << ") Statistics:\n";
+        os << "\tn: " << static_cast<std::size_t>(nqubits + 1) << std::endl;
         os << "\tm: " << getNindividualOps() << std::endl;
         os << "\tseed: " << seed << std::endl;
         os << "\tx: " << x << std::endl;
@@ -160,9 +145,7 @@ namespace qc {
         return os;
     }
 
-    dd::Edge Grover::buildFunctionalityRecursive(std::unique_ptr<dd::Package>& dd) const {
-        dd->setMode(dd::Matrix);
-
+    MatrixDD Grover::buildFunctionalityRecursive(std::unique_ptr<dd::Package>& dd) const {
         QuantumComputation groverIteration(nqubits + 1);
         oracle(groverIteration);
         diffusion(groverIteration);
@@ -170,11 +153,11 @@ namespace qc {
         auto            iter = groverIteration.buildFunctionalityRecursive(dd);
         auto            e    = iter;
         std::bitset<64> iterBits(iterations);
-        auto            msb = static_cast<unsigned short>(std::floor(std::log2(iterations)));
-        dd::Edge        f   = iter;
+        auto            msb = static_cast<std::size_t>(std::floor(std::log2(iterations)));
+        auto            f   = iter;
         dd->incRef(f);
         bool zero = !iterBits[0];
-        for (unsigned int j = 1; j <= msb; ++j) {
+        for (std::size_t j = 1; j <= msb; ++j) {
             auto tmp = dd->multiply(f, f);
             dd->incRef(tmp);
             dd->decRef(f);
@@ -204,8 +187,8 @@ namespace qc {
         e = tmp;
 
         // properly handle ancillary qubit
-        e = reduceAncillae(e, dd);
-        e = reduceGarbage(e, dd);
+        e = dd->reduceAncillae(e, ancillary);
+        e = dd->reduceGarbage(e, garbage);
 
         return e;
     }

--- a/src/algorithms/QFT.cpp
+++ b/src/algorithms/QFT.cpp
@@ -6,47 +6,37 @@
 #include "algorithms/QFT.hpp"
 
 namespace qc {
-    QFT::QFT(unsigned short nq) {
-        nqubits = nq;
-        name    = "qft_" + std::to_string(nq);
-        for (unsigned short i = 0; i < nqubits; ++i) {
-            initialLayout.insert({i, i});
-            outputPermutation.insert({i, nqubits - 1 - i});
+    QFT::QFT(dd::QubitCount nq) {
+        name = "qft_" + std::to_string(static_cast<std::size_t>(nq));
+        addQubitRegister(nq);
+        addClassicalRegister(nq);
+        for (dd::QubitCount i = 0; i < nqubits; ++i) {
+            outputPermutation[static_cast<dd::Qubit>(i)] = static_cast<dd::Qubit>(nqubits - 1 - i);
         }
-        qregs.insert({"q", std::pair<unsigned short, unsigned short>{0, nqubits}});
-        cregs.insert({"c", std::pair<unsigned short, unsigned short>{0, nqubits}});
 
-        for (unsigned short i = 0; i < nqubits; ++i) {
+        for (dd::QubitCount i = 0; i < nqubits; ++i) {
             emplace_back<StandardOperation>(nqubits, i, H);
-            for (unsigned short j = 1; j < nqubits - i; ++j) {
-                long double powerOfTwo = std::pow(2.L, j);
-                auto        lambda     = static_cast<fp>(qc::PI / powerOfTwo);
+            for (dd::QubitCount j = 1; j < nqubits - i; ++j) {
+                auto powerOfTwo = std::pow(2.L, j);
+                auto lambda     = static_cast<dd::fp>(dd::PI / powerOfTwo);
                 if (j == 1) {
-                    emplace_back<StandardOperation>(nqubits, Control(i + 1), i, S);
+                    emplace_back<StandardOperation>(nqubits, dd::Control{static_cast<dd::Qubit>(i + 1)}, i, S);
                 } else if (j == 2) {
-                    emplace_back<StandardOperation>(nqubits, Control(i + 2), i, T);
+                    emplace_back<StandardOperation>(nqubits, dd::Control{static_cast<dd::Qubit>(i + 2)}, i, T);
                 } else {
-                    emplace_back<StandardOperation>(nqubits, Control(i + j), i, Phase, lambda);
+                    emplace_back<StandardOperation>(nqubits, dd::Control{static_cast<dd::Qubit>(i + j)}, i, Phase, lambda);
                 }
             }
         }
 
-        for (unsigned short i = 0; i < nqubits / 2; ++i) {
-            emplace_back<StandardOperation>(nqubits, std::vector<Control>{}, i, static_cast<unsigned short>(nqubits - 1 - i), SWAP);
+        for (dd::Qubit i = 0; i < static_cast<dd::Qubit>(nqubits / 2); ++i) {
+            emplace_back<StandardOperation>(nqubits, dd::Controls{}, i, static_cast<dd::Qubit>(nqubits - 1 - i), SWAP);
         }
     }
 
-    dd::Edge QFT::buildFunctionality(std::unique_ptr<dd::Package>& dd) const {
-        return QuantumComputation::buildFunctionality(dd);
-    }
-
-    dd::Edge QFT::simulate(const dd::Edge& in, std::unique_ptr<dd::Package>& dd) const {
-        return QuantumComputation::simulate(in, dd);
-    }
-
     std::ostream& QFT::printStatistics(std::ostream& os) const {
-        os << "QFT (" << nqubits << ") Statistics:\n";
-        os << "\tn: " << nqubits << std::endl;
+        os << "QFT (" << static_cast<std::size_t>(nqubits) << ") Statistics:\n";
+        os << "\tn: " << static_cast<std::size_t>(nqubits) << std::endl;
         os << "\tm: " << getNindividualOps() << std::endl;
         os << "--------------" << std::endl;
         return os;

--- a/src/algorithms/RandomCliffordCircuit.cpp
+++ b/src/algorithms/RandomCliffordCircuit.cpp
@@ -7,7 +7,8 @@
 
 namespace qc {
 
-    RandomCliffordCircuit::RandomCliffordCircuit(dd::QubitCount nq, std::size_t depth, std::size_t seed): depth(depth), seed(seed) {
+    RandomCliffordCircuit::RandomCliffordCircuit(dd::QubitCount nq, std::size_t depth, std::size_t seed):
+        depth(depth), seed(seed) {
         addQubitRegister(nq);
         addClassicalRegister(nq);
 
@@ -89,7 +90,7 @@ namespace qc {
 
     void RandomCliffordCircuit::append2QClifford(std::uint_fast16_t idx, dd::Qubit control, dd::Qubit target) {
         std::uint_fast16_t id       = idx % 11520;
-        std::uint_fast8_t pauliIdx = id % 16;
+        std::uint_fast8_t  pauliIdx = id % 16;
         id /= 16;
 
         emplace_back<CompoundOperation>(nqubits);

--- a/src/algorithms/RandomCliffordCircuit.cpp
+++ b/src/algorithms/RandomCliffordCircuit.cpp
@@ -7,14 +7,11 @@
 
 namespace qc {
 
-    RandomCliffordCircuit::RandomCliffordCircuit(unsigned short nq, unsigned int depth, unsigned int seed) {
-        this->depth = depth;
-        this->seed  = seed;
-
+    RandomCliffordCircuit::RandomCliffordCircuit(dd::QubitCount nq, std::size_t depth, std::size_t seed): depth(depth), seed(seed) {
         addQubitRegister(nq);
         addClassicalRegister(nq);
 
-        for (unsigned short i = 0; i < nqubits; ++i) {
+        for (dd::QubitCount i = 0; i < nqubits; ++i) {
             initialLayout.insert({i, i});
             outputPermutation.insert({i, i});
         }
@@ -30,22 +27,22 @@ namespace qc {
         } else {
             generator.seed(seed);
         }
-        std::uniform_int_distribution<unsigned short> distribution(0, 11520);
+        std::uniform_int_distribution<std::uint_fast16_t> distribution(0, 11520);
         cliffordGenerator = [&]() { return distribution(generator); };
 
-        for (unsigned int l = 0; l < depth; ++l) {
+        for (std::size_t l = 0; l < depth; ++l) {
             if (nqubits == 1) {
                 append1QClifford(cliffordGenerator(), 0);
             } else if (nqubits == 2) {
                 append2QClifford(cliffordGenerator(), 0, 1);
             } else {
                 if (l % 2) {
-                    for (int i = 1; i < nqubits - 1; i += 2) {
-                        append2QClifford(cliffordGenerator(), i, i + 1);
+                    for (dd::Qubit i = 1; i < static_cast<dd::Qubit>(nqubits - 1); i += 2) {
+                        append2QClifford(cliffordGenerator(), i, static_cast<dd::Qubit>(i + 1));
                     }
                 } else {
-                    for (int i = 0; i < nqubits - 1; i += 2) {
-                        append2QClifford(cliffordGenerator(), i, i + 1);
+                    for (dd::Qubit i = 0; i < static_cast<dd::Qubit>(nqubits - 1); i += 2) {
+                        append2QClifford(cliffordGenerator(), i, static_cast<dd::Qubit>(i + 1));
                     }
                 }
             }
@@ -54,7 +51,7 @@ namespace qc {
 
     std::ostream& RandomCliffordCircuit::printStatistics(std::ostream& os) const {
         os << "Random Clifford circuit statistics:\n";
-        os << "\tn: " << nqubits << std::endl;
+        os << "\tn: " << static_cast<std::size_t>(nqubits) << std::endl;
         os << "\tm: " << getNindividualOps() << std::endl;
         os << "\tdepth: " << depth << std::endl;
         os << "\tseed: " << seed << std::endl;
@@ -62,8 +59,8 @@ namespace qc {
         return os;
     }
 
-    void RandomCliffordCircuit::append1QClifford(unsigned int idx, unsigned short target) {
-        unsigned short id = idx % 24;
+    void RandomCliffordCircuit::append1QClifford(std::uint_fast16_t idx, dd::Qubit target) {
+        std::uint_fast8_t id = idx % 24;
         emplace_back<CompoundOperation>(nqubits);
         auto comp = dynamic_cast<CompoundOperation*>(ops.back().get());
         // Hadamard
@@ -90,9 +87,9 @@ namespace qc {
         }
     }
 
-    void RandomCliffordCircuit::append2QClifford(unsigned int idx, unsigned short control, unsigned short target) {
-        unsigned short id       = idx % 11520;
-        unsigned short pauliIdx = id % 16;
+    void RandomCliffordCircuit::append2QClifford(std::uint_fast16_t idx, dd::Qubit control, dd::Qubit target) {
+        std::uint_fast16_t id       = idx % 11520;
+        std::uint_fast8_t pauliIdx = id % 16;
         id /= 16;
 
         emplace_back<CompoundOperation>(nqubits);
@@ -140,7 +137,7 @@ namespace qc {
                 comp->emplace_back<StandardOperation>(nqubits, target, H);
             }
 
-            comp->emplace_back<StandardOperation>(nqubits, Control(control), target, X);
+            comp->emplace_back<StandardOperation>(nqubits, dd::Control{control}, target, X);
 
             if (id / 9 % 3 == 1) {
                 comp->emplace_back<StandardOperation>(nqubits, control, H);
@@ -179,8 +176,8 @@ namespace qc {
                 comp->emplace_back<StandardOperation>(nqubits, target, H);
             }
 
-            comp->emplace_back<StandardOperation>(nqubits, Control(control), target, X);
-            comp->emplace_back<StandardOperation>(nqubits, Control(target), control, X);
+            comp->emplace_back<StandardOperation>(nqubits, dd::Control{control}, target, X);
+            comp->emplace_back<StandardOperation>(nqubits, dd::Control{target}, control, X);
 
             if (id / 9 % 3 == 1) {
                 comp->emplace_back<StandardOperation>(nqubits, control, H);
@@ -219,9 +216,9 @@ namespace qc {
                 comp->emplace_back<StandardOperation>(nqubits, target, H);
             }
 
-            comp->emplace_back<StandardOperation>(nqubits, Control(control), target, X);
-            comp->emplace_back<StandardOperation>(nqubits, Control(target), control, X);
-            comp->emplace_back<StandardOperation>(nqubits, Control(control), target, X);
+            comp->emplace_back<StandardOperation>(nqubits, dd::Control{control}, target, X);
+            comp->emplace_back<StandardOperation>(nqubits, dd::Control{target}, control, X);
+            comp->emplace_back<StandardOperation>(nqubits, dd::Control{control}, target, X);
         }
 
         if (pauliIdx % 4 == 1) {

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -7,55 +7,47 @@
 
 namespace qc {
     // Measurement constructor
-    NonUnitaryOperation::NonUnitaryOperation(const unsigned short nq, const std::vector<unsigned short>& qubitRegister, const std::vector<unsigned short>& classicalRegister):
-        NonUnitaryOperation(nq, classicalRegister, Measure) {
-        //targets = qubitRegister;
-        //targets = classicalRegister;
+    NonUnitaryOperation::NonUnitaryOperation(const dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, const std::vector<std::size_t>& classicalRegister): qubits(qubitRegister), classics(classicalRegister) {
         assert(qubitRegister.size() == classicalRegister.size());
         // i-th qubit to be measured shall be measured into i-th classical register
-        for (const auto& qubit: qubitRegister)
-            controls.emplace_back(qubit);
+        type = Measure;
+        nqubits = nq;
+        Operation::setName();
     }
-    NonUnitaryOperation::NonUnitaryOperation(unsigned short nq, unsigned short qubit, unsigned short clbit) {
+    NonUnitaryOperation::NonUnitaryOperation(dd::QubitCount nq, dd::Qubit qubit, std::size_t clbit) {
         type    = Measure;
         nqubits = nq;
-        controls.emplace_back(qubit);
-        targets.emplace_back(clbit);
+        qubits.emplace_back(qubit);
+        classics.emplace_back(clbit);
         Operation::setName();
     }
 
     // Snapshot constructor
-    NonUnitaryOperation::NonUnitaryOperation(const unsigned short nq, const std::vector<unsigned short>& qubitRegister, int n):
+    NonUnitaryOperation::NonUnitaryOperation(const dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, std::size_t n):
         NonUnitaryOperation(nq, qubitRegister, Snapshot) {
-        parameter[0] = n;
+        parameter[0] = static_cast<dd::fp>(n);
     }
 
     // General constructor
-    NonUnitaryOperation::NonUnitaryOperation(const unsigned short nq, const std::vector<unsigned short>& qubitRegister, OpType op) {
+    NonUnitaryOperation::NonUnitaryOperation(const dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, OpType op) {
         type    = op;
         nqubits = nq;
         targets = qubitRegister;
         Operation::setName();
     }
 
-    std::ostream& NonUnitaryOperation::print(std::ostream& os) const {
-        return print(os, standardPermutation);
-    }
-
-    std::ostream& NonUnitaryOperation::print(std::ostream& os, const std::map<unsigned short, unsigned short>& permutation) const {
-        std::array<short, MAX_QUBITS> line{};
-        line.fill(LINE_DEFAULT);
-
+    std::ostream& NonUnitaryOperation::printNonUnitary(std::ostream& os, const std::vector<dd::Qubit>& q, const std::vector<std::size_t>& c) const {
+        auto qubitIt = q.cbegin();
+        auto classicIt = c.cbegin();
         switch (type) {
             case Measure:
                 os << name << "\t";
-                for (unsigned int q = 0; q < controls.size(); ++q) {
-                    line[permutation.at(controls[q].qubit)] = static_cast<short>(targets[q]);
-                }
                 for (int i = 0; i < nqubits; ++i) {
-                    if (line[i] >= 0) {
-                        os << "\033[34m" << line[i] << "\t"
+                    if (qubitIt != q.cend() && *qubitIt == i) {
+                        os << "\033[34m" << static_cast<std::size_t>(*classicIt) << "\t"
                            << "\033[0m";
+                        ++qubitIt;
+                        ++classicIt;
                     } else {
                         os << "|\t";
                     }
@@ -63,15 +55,12 @@ namespace qc {
                 break;
             case Reset:
                 os << name << "\t";
-                for (const auto& t: targets) {
-                    if (permutation.find(t) != permutation.end())
-                        line[permutation.at(t)] = LINE_TARGET;
-                }
                 for (int i = 0; i < nqubits; ++i) {
-                    if (line[i] == LINE_TARGET) {
+                    if (qubitIt != q.cend() && *qubitIt == i) {
                         os << "\033[31m"
                            << "r\t"
                            << "\033[0m";
+                        ++qubitIt;
                     } else {
                         os << "|\t";
                     }
@@ -79,35 +68,29 @@ namespace qc {
                 break;
             case Snapshot:
                 os << name << "\t";
-                for (const auto& t: targets) {
-                    if (permutation.find(t) != permutation.end())
-                        line[permutation.at(t)] = LINE_TARGET;
-                }
                 for (int i = 0; i < nqubits; ++i) {
-                    if (line[i] == LINE_TARGET) {
+                    if (qubitIt != q.cend() && *qubitIt == i) {
                         os << "\033[33m"
                            << "s\t"
                            << "\033[0m";
+                        ++qubitIt;
                     } else {
                         os << "|\t";
                     }
                 }
-                os << "\tp: (" << targets.size() << ") (" << parameter[1] << ")";
+                os << "\tp: (" << q.size() << ") (" << parameter[1] << ")";
                 break;
             case ShowProbabilities:
                 os << name;
                 break;
             case Barrier:
                 os << name << "\t";
-                for (const auto& t: targets) {
-                    if (permutation.find(t) != permutation.end())
-                        line[permutation.at(t)] = LINE_TARGET;
-                }
                 for (int i = 0; i < nqubits; ++i) {
-                    if (line[i] == LINE_TARGET) {
+                    if (qubitIt != q.cend() && *qubitIt == i) {
                         os << "\033[32m"
                            << "b\t"
                            << "\033[0m";
+                        ++qubitIt;
                     } else {
                         os << "|\t";
                     }
@@ -120,21 +103,23 @@ namespace qc {
         return os;
     }
 
-    void NonUnitaryOperation::dumpOpenQASM(std::ostream& of, const regnames_t& qreg, const regnames_t& creg) const {
+    void NonUnitaryOperation::dumpOpenQASM(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg) const {
+        auto classicsIt  = classics.cbegin();
         switch (type) {
             case Measure:
-                if (isWholeQubitRegister(qreg, controls[0].qubit, controls.back().qubit) &&
-                    isWholeQubitRegister(qreg, targets[0], targets.back())) {
-                    of << "measure " << qreg[controls[0].qubit].first << " -> " << creg[targets[0]].first << ";" << std::endl;
+                if (isWholeQubitRegister(qreg, qubits.front(), qubits.back()) &&
+                    isWholeQubitRegister(qreg, classics.front(), classics.back())) {
+                    of << "measure " << qreg[qubits.front()].first << " -> " << creg[classics.front()].first << ";" << std::endl;
                 } else {
-                    for (unsigned int q = 0; q < controls.size(); ++q) {
-                        of << "measure " << qreg[controls[q].qubit].second << " -> " << creg[targets[q]].second << ";" << std::endl;
+                    for (const auto& c: qubits) {
+                        of << "measure " << qreg[c].second << " -> " << creg[*classicsIt].second << ";" << std::endl;
+                        ++classicsIt;
                     }
                 }
                 break;
             case Reset:
-                if (isWholeQubitRegister(qreg, targets[0], targets.back())) {
-                    of << "reset " << qreg[targets[0]].first << ";" << std::endl;
+                if (isWholeQubitRegister(qreg, targets.front(), targets.back())) {
+                    of << "reset " << qreg[targets.front()].first << ";" << std::endl;
                 } else {
                     for (const auto& target: targets) {
                         of << "reset " << qreg[target].second << ";" << std::endl;
@@ -158,8 +143,8 @@ namespace qc {
                 of << "show_probabilities;" << std::endl;
                 break;
             case Barrier:
-                if (isWholeQubitRegister(qreg, targets[0], targets.back())) {
-                    of << "barrier " << qreg[targets[0]].first << ";" << std::endl;
+                if (isWholeQubitRegister(qreg, targets.front(), targets.back())) {
+                    of << "barrier " << qreg[targets.front()].first << ";" << std::endl;
                 } else {
                     for (const auto& target: targets) {
                         of << "barrier " << qreg[target].second << ";" << std::endl;
@@ -172,27 +157,27 @@ namespace qc {
         }
     }
 
-    void NonUnitaryOperation::dumpQiskit(std::ostream& of, const regnames_t& qreg, const regnames_t& creg, const char*) const {
+    void NonUnitaryOperation::dumpQiskit(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg, const char*) const {
         switch (type) {
             case Measure:
-                if (isWholeQubitRegister(qreg, controls[0].qubit, controls.back().qubit) &&
-                    isWholeQubitRegister(qreg, targets[0], targets.back())) {
-                    of << "qc.measure(" << qreg[controls[0].qubit].first << ", " << creg[targets[0]].first << ")" << std::endl;
+                if (isWholeQubitRegister(qreg, qubits.front(), qubits.back()) &&
+                    isWholeQubitRegister(qreg, classics.front(), classics.back())) {
+                    of << "qc.measure(" << qreg[qubits.front()].first << ", " << creg[classics.front()].first << ")" << std::endl;
                 } else {
                     of << "qc.measure([";
-                    for (const auto& control: controls) {
-                        of << qreg[control.qubit].second << ", ";
+                    for (const auto& q: qubits) {
+                        of << qreg[q].second << ", ";
                     }
                     of << "], [";
-                    for (unsigned short target: targets) {
+                    for (const auto& target: classics) {
                         of << creg[target].second << ", ";
                     }
                     of << "])" << std::endl;
                 }
                 break;
             case Reset:
-                if (isWholeQubitRegister(qreg, targets[0], targets.back())) {
-                    of << "append(Reset(), " << qreg[targets[0]].first << ", [])" << std::endl;
+                if (isWholeQubitRegister(qreg, targets.front(), targets.back())) {
+                    of << "append(Reset(), " << qreg[targets.front()].first << ", [])" << std::endl;
                 } else {
                     of << "append(Reset(), [";
                     for (const auto& target: targets) {
@@ -204,7 +189,7 @@ namespace qc {
             case Snapshot:
                 if (!targets.empty()) {
                     of << "qc.snapshot(" << parameter[0] << ", qubits=[";
-                    for (unsigned short target: targets) {
+                    for (const auto& target: targets) {
                         of << qreg[target].second << ", ";
                     }
                     of << "])" << std::endl;
@@ -214,8 +199,8 @@ namespace qc {
                 std::cerr << "No equivalent to show_probabilities statement in qiskit" << std::endl;
                 break;
             case Barrier:
-                if (isWholeQubitRegister(qreg, targets[0], targets.back())) {
-                    of << "qc.barrier(" << qreg[targets[0]].first << ")" << std::endl;
+                if (isWholeQubitRegister(qreg, targets.front(), targets.back())) {
+                    of << "qc.barrier(" << qreg[targets.front()].first << ")" << std::endl;
                 } else {
                     of << "qc.barrier([";
                     for (const auto& target: targets) {
@@ -230,7 +215,16 @@ namespace qc {
         }
     }
 
-    dd::Edge NonUnitaryOperation::getDD(std::unique_ptr<dd::Package>& dd, [[maybe_unused]] std::array<short, MAX_QUBITS>& line) const {
+    bool NonUnitaryOperation::actsOn(dd::Qubit i) const {
+        if (type == Measure) {
+            return std::any_of(qubits.cbegin(), qubits.cend(), [&i] (const auto& q) { return q == i; });
+        } else if (type == Reset) {
+            return std::any_of(targets.cbegin(), targets.cend(), [&i] (const auto& t) { return t == i; });
+        }
+        return false; // other non-unitary operations (e.g., barrier statements) may be ignored
+    }
+
+    MatrixDD NonUnitaryOperation::getDD(std::unique_ptr<dd::Package>& dd, [[maybe_unused]] const dd::Controls& controls, [[maybe_unused]] const Targets& targets) const {
         // these operations do not alter the current state
         if (type == ShowProbabilities || type == Barrier || type == Snapshot) {
             return dd->makeIdent(nqubits);
@@ -238,37 +232,12 @@ namespace qc {
 
         throw QFRException("DD for non-unitary operation not available!");
     }
-
-    dd::Edge NonUnitaryOperation::getDD(std::unique_ptr<dd::Package>& dd, [[maybe_unused]] std::array<short, MAX_QUBITS>& line, [[maybe_unused]] std::map<unsigned short, unsigned short>& perm) const {
-        // these operations do not alter the current state
-        if (type == ShowProbabilities || type == Barrier || type == Snapshot) {
-            return dd->makeIdent(nqubits);
-        }
-
-        throw QFRException("DD for non-unitary operation not available!");
-    }
-
-    dd::Edge NonUnitaryOperation::getInverseDD(std::unique_ptr<dd::Package>& dd, [[maybe_unused]] std::array<short, MAX_QUBITS>& line) const {
+    MatrixDD NonUnitaryOperation::getInverseDD(std::unique_ptr<dd::Package>& dd, [[maybe_unused]] const dd::Controls& controls, [[maybe_unused]] const Targets& targets) const {
         // these operations do not alter the current state
         if (type == ShowProbabilities || type == Barrier || type == Snapshot) {
             return dd->makeIdent(nqubits);
         }
 
         throw QFRException("Non-unitary operation is not reversible! No inverse DD is available.");
-    }
-
-    bool NonUnitaryOperation::actsOn(unsigned short i) const {
-        if (type == Measure) {
-            for (const auto& c: controls) {
-                if (c.qubit == i)
-                    return true;
-            }
-        } else if (type == Reset) {
-            for (const auto& t: targets) {
-                if (t == i)
-                    return true;
-            }
-        }
-        return false; // other non-unitary operations (e.g., barrier statements) may be ignored
     }
 } // namespace qc

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -5,10 +5,12 @@
 
 #include "operations/NonUnitaryOperation.hpp"
 
+#include <utility>
+
 namespace qc {
     // Measurement constructor
-    NonUnitaryOperation::NonUnitaryOperation(const dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, const std::vector<std::size_t>& classicalRegister):
-        qubits(qubitRegister), classics(classicalRegister) {
+    NonUnitaryOperation::NonUnitaryOperation(const dd::QubitCount nq, std::vector<dd::Qubit> qubitRegister, std::vector<std::size_t> classicalRegister):
+        qubits(std::move(qubitRegister)), classics(std::move(classicalRegister)) {
         assert(qubitRegister.size() == classicalRegister.size());
         // i-th qubit to be measured shall be measured into i-th classical register
         type    = Measure;

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -7,10 +7,11 @@
 
 namespace qc {
     // Measurement constructor
-    NonUnitaryOperation::NonUnitaryOperation(const dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, const std::vector<std::size_t>& classicalRegister): qubits(qubitRegister), classics(classicalRegister) {
+    NonUnitaryOperation::NonUnitaryOperation(const dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, const std::vector<std::size_t>& classicalRegister):
+        qubits(qubitRegister), classics(classicalRegister) {
         assert(qubitRegister.size() == classicalRegister.size());
         // i-th qubit to be measured shall be measured into i-th classical register
-        type = Measure;
+        type    = Measure;
         nqubits = nq;
         Operation::setName();
     }
@@ -37,7 +38,7 @@ namespace qc {
     }
 
     std::ostream& NonUnitaryOperation::printNonUnitary(std::ostream& os, const std::vector<dd::Qubit>& q, const std::vector<std::size_t>& c) const {
-        auto qubitIt = q.cbegin();
+        auto qubitIt   = q.cbegin();
         auto classicIt = c.cbegin();
         switch (type) {
             case Measure:
@@ -104,7 +105,7 @@ namespace qc {
     }
 
     void NonUnitaryOperation::dumpOpenQASM(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg) const {
-        auto classicsIt  = classics.cbegin();
+        auto classicsIt = classics.cbegin();
         switch (type) {
             case Measure:
                 if (isWholeQubitRegister(qreg, qubits.front(), qubits.back()) &&
@@ -217,9 +218,9 @@ namespace qc {
 
     bool NonUnitaryOperation::actsOn(dd::Qubit i) const {
         if (type == Measure) {
-            return std::any_of(qubits.cbegin(), qubits.cend(), [&i] (const auto& q) { return q == i; });
+            return std::any_of(qubits.cbegin(), qubits.cend(), [&i](const auto& q) { return q == i; });
         } else if (type == Reset) {
-            return std::any_of(targets.cbegin(), targets.cend(), [&i] (const auto& t) { return t == i; });
+            return std::any_of(targets.cbegin(), targets.cend(), [&i](const auto& t) { return t == i; });
         }
         return false; // other non-unitary operations (e.g., barrier statements) may be ignored
     }

--- a/src/operations/Operation.cpp
+++ b/src/operations/Operation.cpp
@@ -177,17 +177,17 @@ namespace qc {
         auto controlIt = controls.cbegin();
         auto targetIt  = targets.cbegin();
         for (const auto& [physical, logical]: permutation) {
-//            std::cout << static_cast<std::size_t>(physical) << " ";
-//            if (targetIt != targets.cend())
-//                std::cout << static_cast<std::size_t>(*targetIt) << " ";
-//            else
-//                std::cout << "x ";
-//
-//            if (controlIt != controls.cend())
-//                std::cout << static_cast<std::size_t>(controlIt->qubit) << " ";
-//            else
-//                std::cout << "x ";
-//            std::cout << std::endl;
+            //            std::cout << static_cast<std::size_t>(physical) << " ";
+            //            if (targetIt != targets.cend())
+            //                std::cout << static_cast<std::size_t>(*targetIt) << " ";
+            //            else
+            //                std::cout << "x ";
+            //
+            //            if (controlIt != controls.cend())
+            //                std::cout << static_cast<std::size_t>(controlIt->qubit) << " ";
+            //            else
+            //                std::cout << "x ";
+            //            std::cout << std::endl;
 
             if (targetIt != targets.cend() && *targetIt == physical) {
                 if (type == ClassicControlled) {

--- a/src/operations/Operation.cpp
+++ b/src/operations/Operation.cpp
@@ -6,8 +6,6 @@
 #include "operations/Operation.hpp"
 
 namespace qc {
-    std::map<unsigned short, unsigned short> Operation::standardPermutation = Operation::create_standard_permutation();
-
     void Operation::setName() {
         switch (type) {
             case I:
@@ -108,66 +106,7 @@ namespace qc {
         }
     }
 
-    void Operation::setLine(std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation) const {
-        for (const auto& target: targets) {
-#if DEBUG_MODE_OPERATIONS
-            std::cout << "target = " << target << ", perm[target] = " << permutation.at(target) << std::endl;
-#endif
-
-            line[permutation.at(target)] = LINE_TARGET;
-        }
-        for (const auto& control: controls) {
-#if DEBUG_MODE_OPERATIONS
-            std::cout << "control = " << control.qubit << ", perm[control] = " << permutation.at(control.qubit) << std::endl;
-#endif
-
-            line[permutation.at(control.qubit)] = control.type == Control::pos ? LINE_CONTROL_POS : LINE_CONTROL_NEG;
-        }
-    }
-
-    void Operation::resetLine(std::array<short, MAX_QUBITS>& line, const std::map<unsigned short, unsigned short>& permutation) const {
-        for (const auto& target: targets) {
-            line[permutation.at(target)] = LINE_DEFAULT;
-        }
-        for (const auto& control: controls) {
-            line[permutation.at(control.qubit)] = LINE_DEFAULT;
-        }
-    }
-
-    std::ostream& Operation::print(std::ostream& os) const {
-        return print(os, standardPermutation);
-    }
-
-    std::ostream& Operation::print(std::ostream& os, const std::map<unsigned short, unsigned short>& permutation) const {
-        const auto prec_before = std::cout.precision(20);
-
-        os << std::setw(4) << name << "\t";
-        std::array<short, MAX_QUBITS> line{};
-        line.fill(-1);
-        setLine(line);
-
-        for (const auto& physical_qubit: permutation) {
-            unsigned short physical_qubit_index = physical_qubit.first;
-            if (line[physical_qubit_index] == LINE_DEFAULT) {
-                os << "|\t";
-            } else if (line[physical_qubit_index] == LINE_CONTROL_NEG) {
-                os << "\033[31m"
-                   << "c\t"
-                   << "\033[0m";
-            } else if (line[physical_qubit_index] == LINE_CONTROL_POS) {
-                os << "\033[32m"
-                   << "c\t"
-                   << "\033[0m";
-            } else {
-                if (type == ClassicControlled) {
-                    os << "\033[1m\033[35m" << name[2] << name[3];
-                } else {
-                    os << "\033[1m\033[36m" << name[0] << name[1];
-                }
-                os << "\t\033[0m";
-            }
-        }
-
+    std::ostream& Operation::printParameters(std::ostream& os) const {
         bool isZero = true;
         for (size_t i = 0; i < MAX_PARAMETERS; ++i) {
             if (parameter[i] != 0.L)
@@ -175,7 +114,7 @@ namespace qc {
         }
         if (!isZero) {
             os << "\tp: (";
-            CN::printFormattedReal(os, parameter[0]);
+            dd::ComplexValue::printFormatted(os, parameter[0]);
             os << ") ";
             for (size_t j = 1; j < MAX_PARAMETERS; ++j) {
                 isZero = true;
@@ -185,10 +124,94 @@ namespace qc {
                 }
                 if (isZero) break;
                 os << "(";
-                CN::printFormattedReal(os, parameter[j]);
+                dd::ComplexValue::printFormatted(os, parameter[j]);
                 os << ") ";
             }
         }
+
+        return os;
+    }
+
+    std::ostream& Operation::print(std::ostream& os) const {
+        const auto prec_before = std::cout.precision(20);
+
+        os << std::setw(4) << name << "\t";
+
+        auto controlIt = controls.begin();
+        auto targetIt  = targets.begin();
+        for (dd::QubitCount i = 0; i < nqubits; ++i) {
+            if (targetIt != targets.end() && *targetIt == static_cast<dd::Qubit>(i)) {
+                if (type == ClassicControlled) {
+                    os << "\033[1m\033[35m" << name[2] << name[3];
+                } else {
+                    os << "\033[1m\033[36m" << name[0] << name[1];
+                }
+                os << "\t\033[0m";
+                ++targetIt;
+            } else if (controlIt != controls.end() && controlIt->qubit == static_cast<dd::Qubit>(i)) {
+                if (controlIt->type == dd::Control::Type::pos) {
+                    os << "\033[32m";
+                } else {
+                    os << "\033[31m";
+                }
+                os << "c\t"
+                   << "\033[0m";
+                ++controlIt;
+            } else {
+                os << "|\t";
+            }
+        }
+
+        printParameters(os);
+
+        std::cout.precision(prec_before);
+
+        return os;
+    }
+
+    std::ostream& Operation::print(std::ostream& os, const Permutation& permutation) const {
+        const auto prec_before = std::cout.precision(20);
+
+        os << std::setw(4) << name << "\t";
+
+        auto controlIt = controls.cbegin();
+        auto targetIt  = targets.cbegin();
+        for (const auto& [physical, logical]: permutation) {
+//            std::cout << static_cast<std::size_t>(physical) << " ";
+//            if (targetIt != targets.cend())
+//                std::cout << static_cast<std::size_t>(*targetIt) << " ";
+//            else
+//                std::cout << "x ";
+//
+//            if (controlIt != controls.cend())
+//                std::cout << static_cast<std::size_t>(controlIt->qubit) << " ";
+//            else
+//                std::cout << "x ";
+//            std::cout << std::endl;
+
+            if (targetIt != targets.cend() && *targetIt == physical) {
+                if (type == ClassicControlled) {
+                    os << "\033[1m\033[35m" << name[2] << name[3];
+                } else {
+                    os << "\033[1m\033[36m" << name[0] << name[1];
+                }
+                os << "\t\033[0m";
+                ++targetIt;
+            } else if (controlIt != controls.cend() && controlIt->qubit == physical) {
+                if (controlIt->type == dd::Control::Type::pos) {
+                    os << "\033[32m";
+                } else {
+                    os << "\033[31m";
+                }
+                os << "c\t"
+                   << "\033[0m";
+                ++controlIt;
+            } else {
+                os << "|\t";
+            }
+        }
+
+        printParameters(os);
 
         std::cout.precision(prec_before);
 

--- a/src/operations/StandardOperation.cpp
+++ b/src/operations/StandardOperation.cpp
@@ -245,28 +245,22 @@ namespace qc {
 
     StandardOperation::StandardOperation(dd::QubitCount nq, dd::Control control, dd::Qubit target, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta):
         StandardOperation(nq, target, g, lambda, phi, theta) {
-        controlled = true;
         controls.insert(control);
     }
 
     StandardOperation::StandardOperation(dd::QubitCount nq, dd::Control control, const Targets& targets, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta):
         StandardOperation(nq, targets, g, lambda, phi, theta) {
-        controlled = true;
         controls.insert(control);
     }
 
     StandardOperation::StandardOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta):
         StandardOperation(nq, target, g, lambda, phi, theta) {
         this->controls = controls;
-        if (!controls.empty())
-            controlled = true;
     }
 
     StandardOperation::StandardOperation(dd::QubitCount nq, const dd::Controls& controls, const Targets& targets, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta):
         StandardOperation(nq, targets, g, lambda, phi, theta) {
         this->controls = controls;
-        if (!controls.empty())
-            controlled = true;
     }
 
     // MCT Constructor

--- a/src/parsers/GRCSParser.cpp
+++ b/src/parsers/GRCSParser.cpp
@@ -6,12 +6,16 @@
 #include "QuantumComputation.hpp"
 
 void qc::QuantumComputation::importGRCS(std::istream& is) {
-    is >> nqubits;
-    std::string    line;
-    std::string    identifier;
-    unsigned short control = 0;
-    unsigned short target  = 0;
-    unsigned int   cycle   = 0;
+    std::size_t nq;
+    is >> nq;
+    addQubitRegister(nq);
+    addClassicalRegister(nq);
+
+    std::string line;
+    std::string identifier;
+    std::size_t control = 0;
+    std::size_t target  = 0;
+    std::size_t cycle   = 0;
     while (std::getline(is, line)) {
         if (line.empty()) continue;
         std::stringstream ss(line);
@@ -20,11 +24,11 @@ void qc::QuantumComputation::importGRCS(std::istream& is) {
         if (identifier == "cz") {
             ss >> control;
             ss >> target;
-            emplace_back<StandardOperation>(nqubits, Control(control), target, Z);
+            emplace_back<StandardOperation>(nqubits, dd::Control{static_cast<dd::Qubit>(control)}, target, Z);
         } else if (identifier == "is") {
             ss >> control;
             ss >> target;
-            emplace_back<StandardOperation>(nqubits, std::vector<qc::Control>{}, control, target, iSWAP);
+            emplace_back<StandardOperation>(nqubits, dd::Controls{}, control, target, iSWAP);
         } else {
             ss >> target;
             if (identifier == "h")
@@ -32,17 +36,12 @@ void qc::QuantumComputation::importGRCS(std::istream& is) {
             else if (identifier == "t")
                 emplace_back<StandardOperation>(nqubits, target, T);
             else if (identifier == "x_1_2")
-                emplace_back<StandardOperation>(nqubits, target, RX, PI_2);
+                emplace_back<StandardOperation>(nqubits, target, RX, dd::PI_2);
             else if (identifier == "y_1_2")
-                emplace_back<StandardOperation>(nqubits, target, RY, PI_2);
+                emplace_back<StandardOperation>(nqubits, target, RY, dd::PI_2);
             else {
                 throw QFRException("[grcs parser] unknown gate '" + identifier + "'");
             }
         }
-    }
-
-    for (unsigned short i = 0; i < nqubits; ++i) {
-        initialLayout.insert({i, i});
-        outputPermutation.insert({i, i});
     }
 }

--- a/src/parsers/TFCParser.cpp
+++ b/src/parsers/TFCParser.cpp
@@ -6,12 +6,12 @@
 #include "QuantumComputation.hpp"
 
 void qc::QuantumComputation::importTFC(std::istream& is) {
-    std::map<std::string, unsigned short> varMap{};
+    std::map<std::string, dd::Qubit> varMap{};
     auto                                  line = readTFCHeader(is, varMap);
     readTFCGateDescriptions(is, line, varMap);
 }
 
-int qc::QuantumComputation::readTFCHeader(std::istream& is, std::map<std::string, unsigned short>& varMap) {
+int qc::QuantumComputation::readTFCHeader(std::istream& is, std::map<std::string, dd::Qubit>& varMap) {
     std::string cmd;
     std::string variable;
     std::string identifier;
@@ -137,24 +137,24 @@ int qc::QuantumComputation::readTFCHeader(std::istream& is, std::map<std::string
     for (size_t q = 0; q < variables.size(); ++q) {
         variable         = variables.at(q);
         auto p           = varMap.at(variable);
-        initialLayout[q] = p;
+        initialLayout[static_cast<dd::Qubit>(q)] = p;
         if (!outputs.empty()) {
             if (std::count(outputs.begin(), outputs.end(), variable)) {
-                outputPermutation[q] = p;
+                outputPermutation[static_cast<dd::Qubit>(q)] = p;
             } else {
-                outputPermutation.erase(q);
-                garbage.set(p);
+                outputPermutation.erase(static_cast<dd::Qubit>(q));
+                garbage.at(p) = true;
             }
         } else {
             // no output statement given --> assume all outputs are relevant
-            outputPermutation[q] = p;
+            outputPermutation[static_cast<dd::Qubit>(q)] = p;
         }
     }
 
     return line;
 }
 
-void qc::QuantumComputation::readTFCGateDescriptions(std::istream& is, int line, std::map<std::string, unsigned short>& varMap) {
+void qc::QuantumComputation::readTFCGateDescriptions(std::istream& is, int line, std::map<std::string, dd::Qubit>& varMap) {
     std::regex  gateRegex = std::regex("([tTfF])(\\d+)");
     std::smatch m;
     std::string cmd;
@@ -185,7 +185,7 @@ void qc::QuantumComputation::readTFCGateDescriptions(std::istream& is, int line,
             } else {
                 gate = SWAP;
             }
-            unsigned short ncontrols = m.str(2).empty() ? 0 : static_cast<unsigned short>(std::stoul(m.str(2), nullptr, 0)) - 1;
+            dd::QubitCount ncontrols = m.str(2).empty() ? 0 : static_cast<dd::QubitCount>(std::stoul(m.str(2), nullptr, 0)) - 1;
 
             if (ncontrols >= nqubits + nancillae) {
                 throw QFRException("[tfc parser] l:" + std::to_string(line) + " msg: Gate acts on " + std::to_string(ncontrols + 1) + " qubits, but only " + std::to_string(nqubits + nancillae) + " qubits are available.");
@@ -195,7 +195,7 @@ void qc::QuantumComputation::readTFCGateDescriptions(std::istream& is, int line,
             is >> std::ws;
             getline(is, qubits);
 
-            std::vector<Control> controls{};
+            std::vector<dd::Control> controls{};
 
             std::string delimiter = ",";
             size_t      pos;
@@ -204,24 +204,24 @@ void qc::QuantumComputation::readTFCGateDescriptions(std::istream& is, int line,
                 label = qubits.substr(0, pos);
                 if (label.back() == '\'') {
                     label.erase(label.size() - 1);
-                    controls.emplace_back(varMap.at(label), Control::neg);
+                    controls.emplace_back(dd::Control{varMap.at(label), dd::Control::Type::neg});
                 } else {
-                    controls.emplace_back(varMap.at(label));
+                    controls.emplace_back(dd::Control{varMap.at(label)});
                 }
                 qubits.erase(0, pos + 1);
             }
-            controls.emplace_back(varMap.at(qubits));
+            controls.emplace_back(dd::Control{varMap.at(qubits)});
 
             if (gate == X) {
-                unsigned short target = controls.back().qubit;
+                dd::Qubit target = controls.back().qubit;
                 controls.pop_back();
-                emplace_back<StandardOperation>(nqubits, controls, target);
+                emplace_back<StandardOperation>(nqubits, dd::Controls{controls.cbegin(), controls.cend()}, target);
             } else {
-                unsigned short target0 = controls.back().qubit;
+                dd::Qubit target0 = controls.back().qubit;
                 controls.pop_back();
-                unsigned short target1 = controls.back().qubit;
+                dd::Qubit target1 = controls.back().qubit;
                 controls.pop_back();
-                emplace_back<StandardOperation>(nqubits, controls, target0, target1, gate);
+                emplace_back<StandardOperation>(nqubits, dd::Controls{controls.cbegin(), controls.cend()}, target0, target1, gate);
             }
         }
     }

--- a/src/parsers/TFCParser.cpp
+++ b/src/parsers/TFCParser.cpp
@@ -7,7 +7,7 @@
 
 void qc::QuantumComputation::importTFC(std::istream& is) {
     std::map<std::string, dd::Qubit> varMap{};
-    auto                                  line = readTFCHeader(is, varMap);
+    auto                             line = readTFCHeader(is, varMap);
     readTFCGateDescriptions(is, line, varMap);
 }
 
@@ -135,8 +135,8 @@ int qc::QuantumComputation::readTFCHeader(std::istream& is, std::map<std::string
     }
 
     for (size_t q = 0; q < variables.size(); ++q) {
-        variable         = variables.at(q);
-        auto p           = varMap.at(variable);
+        variable                                 = variables.at(q);
+        auto p                                   = varMap.at(variable);
         initialLayout[static_cast<dd::Qubit>(q)] = p;
         if (!outputs.empty()) {
             if (std::count(outputs.begin(), outputs.end(), variable)) {

--- a/src/parsers/qasm_parser/Parser.cpp
+++ b/src/parsers/qasm_parser/Parser.cpp
@@ -843,7 +843,7 @@ namespace qasm {
         IdList(gate.argumentNames);
         check(Token::Kind::lbrace);
 
-        auto         cGateName = gateName;
+        auto           cGateName = gateName;
         dd::QubitCount ncontrols = 0;
         while (cGateName.front() == 'c') {
             cGateName = cGateName.substr(1);
@@ -1065,10 +1065,10 @@ namespace qasm {
             check(Token::Kind::semicolon);
 
             if (qreg.second == creg.second) {
-                std::vector<dd::Qubit> qubits{};
+                std::vector<dd::Qubit>   qubits{};
                 std::vector<std::size_t> classics{};
                 for (int i = 0; i < qreg.second; ++i) {
-                    auto qubit = static_cast<dd::Qubit>(qreg.first + i);
+                    auto        qubit = static_cast<dd::Qubit>(qreg.first + i);
                     std::size_t clbit = creg.first + i;
                     if (qubit >= nqubits) {
                         std::stringstream ss{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ endif ()
 
 add_executable(${PROJECT_NAME}_example ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 target_link_libraries(${PROJECT_NAME}_example PRIVATE ${PROJECT_NAME})
+set_target_properties(${PROJECT_NAME}_example PROPERTIES FOLDER tests CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
 
 add_custom_command(TARGET ${PROJECT_NAME}_example
                    POST_BUILD
@@ -33,7 +34,7 @@ macro(package_add_test TESTNAME)
 	target_link_libraries(${TESTNAME} PRIVATE ${PROJECT_NAME} gmock gtest_main)
 	# discover tests
 	gtest_discover_tests(${TESTNAME} WORKING_DIRECTORY ${PROJECT_DIR} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}")
-	set_target_properties(${TESTNAME} PROPERTIES FOLDER tests)
+	set_target_properties(${TESTNAME} PROPERTIES FOLDER tests CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
 endmacro()
 
 # add unit tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,12 +12,18 @@ if (NOT TARGET gtest OR NOT TARGET gmock)
 		# adjust visibility settings for building Python bindings
 		target_compile_options(gtest PUBLIC -fvisibility=hidden)
 		target_compile_options(gmock PUBLIC -fvisibility=hidden)
-	endif()
+	endif ()
 endif ()
 
 add_executable(${PROJECT_NAME}_example ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 target_link_libraries(${PROJECT_NAME}_example PRIVATE ${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME}_example PROPERTIES FOLDER tests CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
+# enable interprocedural optimization if it is supported
+include(CheckIPOSupported)
+check_ipo_supported(RESULT ipo_supported)
+if (ipo_supported)
+	set_target_properties(${PROJECT_NAME}_example PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif ()
 
 add_custom_command(TARGET ${PROJECT_NAME}_example
                    POST_BUILD
@@ -35,18 +41,24 @@ macro(package_add_test TESTNAME)
 	# discover tests
 	gtest_discover_tests(${TESTNAME} WORKING_DIRECTORY ${PROJECT_DIR} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}")
 	set_target_properties(${TESTNAME} PROPERTIES FOLDER tests CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
+	# enable interprocedural optimization if it is supported
+	include(CheckIPOSupported)
+	check_ipo_supported(RESULT ipo_supported)
+	if (ipo_supported)
+		set_target_properties(${TESTNAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+	endif ()
 endmacro()
 
 # add unit tests
 package_add_test(${PROJECT_NAME}_test ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_qft.cpp
-							${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_grover.cpp 
-							${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_bernsteinvazirani.cpp
-							${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_entanglement.cpp
-                            ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_grcs.cpp
-                            ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_random_clifford.cpp
-							${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_io.cpp
-							${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_ddfunctionality.cpp
-                            ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_qfr_functionality.cpp)
+                 ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_grover.cpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_bernsteinvazirani.cpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_entanglement.cpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_grcs.cpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_random_clifford.cpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_io.cpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_ddfunctionality.cpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_qfr_functionality.cpp)
 
 add_custom_command(TARGET ${PROJECT_NAME}_test
                    POST_BUILD
@@ -55,3 +67,54 @@ add_custom_command(TARGET ${PROJECT_NAME}_test
                    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_DIR:${PROJECT_NAME}_test>/circuits ${CMAKE_BINARY_DIR}/circuits
                    COMMENT "Copying circuits and creating symlinks for ${PROJECT_NAME}_test"
                    VERBATIM)
+
+if (CMAKE_BUILD_TYPE MATCHES pgotrain)
+
+	if (CMAKE_COMPILER_IS_GNUCXX)
+		SET(PGO_COMPILE_FLAGS "-fprofile-generate=${CMAKE_BINARY_DIR}/profile-data")
+	endif ()
+	if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
+		SET(PGO_COMPILE_FLAGS "-fprofile-instr-generate -g -O0  -fprofile-arcs -ftest-coverage")
+	endif ()
+
+	# Add the CMAKE_CXX_FLAGS_RELEASE so that a PGO optimized build also includes release flags
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} ${PGO_COMPILE_FLAGS}")
+
+endif ()
+
+if (CMAKE_BUILD_TYPE MATCHES pgobuild)
+	# Where to find the profiling data from the training run
+	if (NOT PGO_TRAINING_DIR)
+		SET(PGO_TRAINING_DIR ../training)
+	endif ()
+	SET(PGO_TRAINING_DATA ${CMAKE_BINARY_DIR}/${PGO_TRAINING_DIR}/profile-data)
+
+	if (NOT EXISTS ${PGO_TRAINING_DATA})
+		message(FATAL_ERROR "No profiling Data Found so can't Build. Ensure that the training run was executed in the training build directory. Training data expected in Directory: " ${PGO_TRAINING_DATA})
+	endif ()
+
+	if (CMAKE_COMPILER_IS_GNUCXX)
+		SET(PGO_COMPILE_FLAGS "-fprofile-use=${PGO_TRAINING_DATA} -fprofile-correction")
+	endif ()
+	if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
+		SET(PGO_COMPILE_FLAGS "-fprofile-instr-use -g -O0  -fprofile-arcs -ftest-coverage")
+	endif ()
+
+	# This custom target always runs.
+	# It launches 2 commands which will run in the directory specified by PGO_TRAINING_DIR.
+	# First, it runs 'make all' in the Profile instrumented build area
+	# Next it runs 'make test' to ensure that the profiling information is generated.
+	# In this way, running 'make all' in the final build area guarantees that the Profile
+	# instrumented training files will be re-compiled, then the test suite will be run
+	# to generate new profiling files, before the final build version is compiled using
+	# this profiling information.
+	add_custom_target(run_training
+	                  ALL
+	                  WORKING_DIRECTORY ${PGO_TRAINING_DIR}
+	                  COMMAND ${CMAKE_BUILD_TOOL} all
+	                  COMMAND ${CMAKE_BUILD_TOOL} ${PROJECT_NAME}_test
+	                  VERBATIM)
+
+	# Add the CMAKE_CXX_FLAGS_RELEASE so that a PGO optimized build also includes release flags
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} ${PGO_COMPILE_FLAGS}")
+endif ()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,12 +18,7 @@ endif ()
 add_executable(${PROJECT_NAME}_example ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 target_link_libraries(${PROJECT_NAME}_example PRIVATE ${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME}_example PROPERTIES FOLDER tests CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
-# enable interprocedural optimization if it is supported
-include(CheckIPOSupported)
-check_ipo_supported(RESULT ipo_supported)
-if (ipo_supported)
-	set_target_properties(${PROJECT_NAME}_example PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
-endif ()
+enable_lto(${PROJECT_NAME}_example)
 
 add_custom_command(TARGET ${PROJECT_NAME}_example
                    POST_BUILD
@@ -41,12 +36,7 @@ macro(package_add_test TESTNAME)
 	# discover tests
 	gtest_discover_tests(${TESTNAME} WORKING_DIRECTORY ${PROJECT_DIR} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}")
 	set_target_properties(${TESTNAME} PROPERTIES FOLDER tests CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
-	# enable interprocedural optimization if it is supported
-	include(CheckIPOSupported)
-	check_ipo_supported(RESULT ipo_supported)
-	if (ipo_supported)
-		set_target_properties(${TESTNAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
-	endif ()
+	enable_lto(${TESTNAME})
 endmacro()
 
 # add unit tests
@@ -67,54 +57,3 @@ add_custom_command(TARGET ${PROJECT_NAME}_test
                    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_DIR:${PROJECT_NAME}_test>/circuits ${CMAKE_BINARY_DIR}/circuits
                    COMMENT "Copying circuits and creating symlinks for ${PROJECT_NAME}_test"
                    VERBATIM)
-
-if (CMAKE_BUILD_TYPE MATCHES pgotrain)
-
-	if (CMAKE_COMPILER_IS_GNUCXX)
-		SET(PGO_COMPILE_FLAGS "-fprofile-generate=${CMAKE_BINARY_DIR}/profile-data")
-	endif ()
-	if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
-		SET(PGO_COMPILE_FLAGS "-fprofile-instr-generate -g -O0  -fprofile-arcs -ftest-coverage")
-	endif ()
-
-	# Add the CMAKE_CXX_FLAGS_RELEASE so that a PGO optimized build also includes release flags
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} ${PGO_COMPILE_FLAGS}")
-
-endif ()
-
-if (CMAKE_BUILD_TYPE MATCHES pgobuild)
-	# Where to find the profiling data from the training run
-	if (NOT PGO_TRAINING_DIR)
-		SET(PGO_TRAINING_DIR ../training)
-	endif ()
-	SET(PGO_TRAINING_DATA ${CMAKE_BINARY_DIR}/${PGO_TRAINING_DIR}/profile-data)
-
-	if (NOT EXISTS ${PGO_TRAINING_DATA})
-		message(FATAL_ERROR "No profiling Data Found so can't Build. Ensure that the training run was executed in the training build directory. Training data expected in Directory: " ${PGO_TRAINING_DATA})
-	endif ()
-
-	if (CMAKE_COMPILER_IS_GNUCXX)
-		SET(PGO_COMPILE_FLAGS "-fprofile-use=${PGO_TRAINING_DATA} -fprofile-correction")
-	endif ()
-	if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
-		SET(PGO_COMPILE_FLAGS "-fprofile-instr-use -g -O0  -fprofile-arcs -ftest-coverage")
-	endif ()
-
-	# This custom target always runs.
-	# It launches 2 commands which will run in the directory specified by PGO_TRAINING_DIR.
-	# First, it runs 'make all' in the Profile instrumented build area
-	# Next it runs 'make test' to ensure that the profiling information is generated.
-	# In this way, running 'make all' in the final build area guarantees that the Profile
-	# instrumented training files will be re-compiled, then the test suite will be run
-	# to generate new profiling files, before the final build version is compiled using
-	# this profiling information.
-	add_custom_target(run_training
-	                  ALL
-	                  WORKING_DIRECTORY ${PGO_TRAINING_DIR}
-	                  COMMAND ${CMAKE_BUILD_TOOL} all
-	                  COMMAND ${CMAKE_BUILD_TOOL} ${PROJECT_NAME}_test
-	                  VERBATIM)
-
-	# Add the CMAKE_CXX_FLAGS_RELEASE so that a PGO optimized build also includes release flags
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} ${PGO_COMPILE_FLAGS}")
-endif ()

--- a/test/algorithms/test_bernsteinvazirani.cpp
+++ b/test/algorithms/test_bernsteinvazirani.cpp
@@ -29,26 +29,26 @@ INSTANTIATE_TEST_SUITE_P(BernsteinVazirani, BernsteinVazirani,
 
 TEST_P(BernsteinVazirani, FunctionTest) {
     std::bitset<64>                        hInt = GetParam();
-    auto                                   dd   = std::make_unique<dd::Package>();
     std::unique_ptr<qc::BernsteinVazirani> qc;
-    dd::Edge                               e{};
+    qc::MatrixDD                           e{};
 
     // Create the QuantumCircuite with the hidden integer
     ASSERT_NO_THROW({ qc = std::make_unique<qc::BernsteinVazirani>(hInt.to_ulong()); });
     qc->printStatistics(std::cout);
+    auto dd = std::make_unique<dd::Package>(qc->size);
     ASSERT_NO_THROW({ e = qc->buildFunctionality(dd); });
 
     // Test the Number of Operations & the number of Qubits
     ASSERT_EQ(qc->getNops(), qc->size * 2 + hInt.count());
     ASSERT_EQ(qc->getNqubits(), qc->size);
 
-    dd::Edge    r        = dd->multiply(e, dd->makeZeroState(qc->size));
-    std::string hIntPath = std::string(qc->size, '0');
+    auto r        = dd->multiply(e, dd->makeZeroState(qc->size));
+    auto hIntPath = std::string(qc->size, '0');
 
     // Create the path-string
-    for (unsigned int i = 0; i < qc->size; i++) {
+    for (dd::QubitCount i = 0; i < qc->size; i++) {
         if (hInt[i] == 1) {
-            hIntPath[i] = '2';
+            hIntPath[i] = '1';
         }
     }
 

--- a/test/algorithms/test_entanglement.cpp
+++ b/test/algorithms/test_entanglement.cpp
@@ -8,35 +8,35 @@
 #include "gtest/gtest.h"
 #include <string>
 
-class Entanglement: public testing::TestWithParam<unsigned short> {
+class Entanglement: public testing::TestWithParam<dd::QubitCount> {
 protected:
     void TearDown() override {}
     void SetUp() override {}
 };
 
 INSTANTIATE_TEST_SUITE_P(Entanglement, Entanglement,
-                         testing::Range((unsigned short)2, (unsigned short)129, 7),
+                         testing::Range(static_cast<dd::QubitCount>(2), static_cast<dd::QubitCount>(129), 7),
                          [](const testing::TestParamInfo<Entanglement::ParamType>& info) {
                              // Generate names for test cases
-                             unsigned short    nqubits = info.param;
+                             dd::QubitCount    nqubits = info.param;
                              std::stringstream ss{};
-                             ss << nqubits << "_qubits";
+                             ss << static_cast<std::size_t>(nqubits) << "_qubits";
                              return ss.str();
                          });
 
 TEST_P(Entanglement, FunctionTest) {
-    const unsigned short nq = GetParam();
+    const dd::QubitCount nq = GetParam();
 
-    auto                              dd = std::make_unique<dd::Package>();
+    auto                              dd = std::make_unique<dd::Package>(nq);
     std::unique_ptr<qc::Entanglement> qc;
-    dd::Edge                          e{};
+    qc::MatrixDD                      e{};
 
     ASSERT_NO_THROW({ qc = std::make_unique<qc::Entanglement>(nq); });
     ASSERT_NO_THROW({ e = qc->buildFunctionality(dd); });
 
     ASSERT_EQ(qc->getNops(), nq);
-    dd::Edge r = dd->multiply(e, dd->makeZeroState(nq));
+    qc::VectorDD r = dd->multiply(e, dd->makeZeroState(nq));
 
-    ASSERT_EQ(dd->getValueByPath(r, std::string(nq, '0')), (dd::ComplexValue{dd::SQRT_2, 0}));
-    ASSERT_EQ(dd->getValueByPath(r, std::string(nq, '2')), (dd::ComplexValue{dd::SQRT_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(r, std::string(nq, '0')), (dd::ComplexValue{dd::SQRT2_2, 0}));
+    ASSERT_EQ(dd->getValueByPath(r, std::string(nq, '1')), (dd::ComplexValue{dd::SQRT2_2, 0}));
 }

--- a/test/algorithms/test_grcs.cpp
+++ b/test/algorithms/test_grcs.cpp
@@ -26,7 +26,7 @@ TEST_F(GRCS, import) {
 TEST_F(GRCS, simulate) {
     auto qc_bris = qc::GoogleRandomCircuitSampling("./circuits/grcs/bris_4_40_9_v2.txt");
 
-    auto dd = std::make_unique<dd::Package>();
+    auto dd = std::make_unique<dd::Package>(qc_bris.getNqubits());
     auto in = dd->makeZeroState(qc_bris.getNqubits());
     ASSERT_NO_THROW({
         qc_bris.simulate(in, dd, 4);
@@ -38,7 +38,7 @@ TEST_F(GRCS, simulate) {
 TEST_F(GRCS, buildFunctionality) {
     auto qc_bris = qc::GoogleRandomCircuitSampling("./circuits/grcs/bris_4_40_9_v2.txt");
 
-    auto dd = std::make_unique<dd::Package>();
+    auto dd = std::make_unique<dd::Package>(qc_bris.getNqubits());
     ASSERT_NO_THROW({
         qc_bris.buildFunctionality(dd, 4);
     });

--- a/test/algorithms/test_grover.cpp
+++ b/test/algorithms/test_grover.cpp
@@ -20,9 +20,10 @@ protected:
 
         // number of complex table entries after clean-up should equal initial number of entries
         EXPECT_EQ(dd->cn.complexTable.getCount(), initialComplexCount);
-        if (dd->cn.complexTable.getCount() != initialComplexCount) {
-            dd->cn.complexTable.print();
-        }
+        // if (dd->cn.complexTable.getCount() != initialComplexCount) {
+        //     dd->cn.complexTable.print();
+        // }
+
         // number of available cache entries after clean-up should equal initial number of entries
         EXPECT_EQ(dd->cn.complexCache.getCount(), initialCacheCount);
     }

--- a/test/algorithms/test_grover.cpp
+++ b/test/algorithms/test_grover.cpp
@@ -44,7 +44,7 @@ protected:
     qc::MatrixDD                 func{};
 };
 
-constexpr dd::QubitCount GROVER_MAX_QUBITS       = 23;
+constexpr dd::QubitCount GROVER_MAX_QUBITS       = 18;
 constexpr std::size_t    GROVER_NUM_SEEDS        = 5;
 constexpr dd::fp         GROVER_ACCURACY         = 1e-2;
 constexpr dd::fp         GROVER_GOAL_PROBABILITY = 0.9;

--- a/test/algorithms/test_grover.cpp
+++ b/test/algorithms/test_grover.cpp
@@ -19,10 +19,10 @@ protected:
         dd->garbageCollect(true);
 
         // number of complex table entries after clean-up should equal initial number of entries
-        //EXPECT_EQ(dd->cn.count, initialComplexCount); TODO: fix the numerical issue that inserts two values very close to 1/sqrt(2)
-        //if (dd->cn.count != initialComplexCount) {
-        //	dd->cn.printComplexTable();
-        //}
+        EXPECT_EQ(dd->cn.complexTable.getCount(), initialComplexCount);
+        if (dd->cn.complexTable.getCount() != initialComplexCount) {
+            dd->cn.complexTable.print();
+        }
         // number of available cache entries after clean-up should equal initial number of entries
         EXPECT_EQ(dd->cn.complexCache.getCount(), initialCacheCount);
     }

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -25,7 +25,7 @@ protected:
     }
 
     void SetUp() override {
-        nqubits = GetParam();
+        nqubits             = GetParam();
         dd                  = std::make_unique<dd::Package>(nqubits);
         initialCacheCount   = dd->cn.complexCache.getCount();
         initialComplexCount = dd->cn.complexTable.getCount();

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -82,8 +82,7 @@ TEST_P(QFT, Functionality) {
     // the final DD should store all 2^n different amplitudes
     // since only positive real values are stored in the complex table
     // this number has to be divided by 4
-    // the (+3) accounts for the fact that the table is pre-filled with some values {0,0.5,sqrt(0.5)}
-    ASSERT_EQ(dd->cn.complexTable.getCount(), static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)) + 3);
+    ASSERT_EQ(dd->cn.complexTable.getCount(), static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)));
 
     // top edge weight should equal sqrt(0.5)^n
     EXPECT_NEAR(dd::ComplexTable<>::Entry::val(func.w.r), static_cast<dd::fp>(std::pow(1.L / std::sqrt(2.L), nqubits)), dd->cn.complexTable.tolerance());
@@ -116,8 +115,7 @@ TEST_P(QFT, FunctionalityRecursive) {
     // the final DD should store all 2^n different amplitudes
     // since only positive real values are stored in the complex table
     // this number has to be divided by 4
-    // the (+3) accounts for the fact that the table is pre-filled with some values {0,0.5,sqrt(0.5)}
-    ASSERT_EQ(dd->cn.complexTable.getCount(), static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)) + 3);
+    ASSERT_EQ(dd->cn.complexTable.getCount(), static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)));
 
     // top edge weight should equal sqrt(0.5)^n
     EXPECT_NEAR(dd::ComplexTable<>::Entry::val(func.w.r), static_cast<dd::fp>(std::pow(1.L / std::sqrt(2.L), nqubits)), dd->cn.complexTable.tolerance());

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -9,30 +9,35 @@
 #include <cmath>
 #include <iostream>
 
-class QFT: public testing::TestWithParam<unsigned short> {
+class QFT: public testing::TestWithParam<dd::QubitCount> {
 protected:
     void TearDown() override {
-        dd->decRef(e);
+        if (!sim.isTerminal())
+            dd->decRef(sim);
+        if (!func.isTerminal())
+            dd->decRef(func);
         dd->garbageCollect(true);
 
         // number of complex table entries after clean-up should equal initial number of entries
-        EXPECT_EQ(dd->cn.count, initialComplexCount);
+        EXPECT_EQ(dd->cn.complexTable.getCount(), initialComplexCount);
         // number of available cache entries after clean-up should equal initial number of entries
-        EXPECT_EQ(dd->cn.cacheCount, initialCacheCount);
+        EXPECT_EQ(dd->cn.complexCache.getCount(), initialCacheCount);
     }
 
     void SetUp() override {
-        dd                  = std::make_unique<dd::Package>();
-        initialCacheCount   = dd->cn.cacheCount;
-        initialComplexCount = dd->cn.count;
+        nqubits = GetParam();
+        dd                  = std::make_unique<dd::Package>(nqubits);
+        initialCacheCount   = dd->cn.complexCache.getCount();
+        initialComplexCount = dd->cn.complexTable.getCount();
     }
 
-    unsigned short               nqubits = 0;
+    dd::QubitCount               nqubits = 0;
     std::unique_ptr<dd::Package> dd;
     std::unique_ptr<qc::QFT>     qc;
-    long                         initialCacheCount   = 0;
-    unsigned int                 initialComplexCount = 0;
-    dd::Edge                     e{};
+    std::size_t                  initialCacheCount   = 0;
+    std::size_t                  initialComplexCount = 0;
+    qc::VectorDD                 sim{};
+    qc::MatrixDD                 func{};
 };
 
 /// Findings from the QFT Benchmarks:
@@ -45,14 +50,14 @@ protected:
 ///		10e-13	..	23 qubits
 /// The accuracy of double floating points allows for a minimal CN::TOLERANCE value of 10e-15
 ///	Utilizing more qubits requires the use of fp=long double
-constexpr unsigned short QFT_MAX_QUBITS = 20;
+constexpr dd::QubitCount QFT_MAX_QUBITS = 20;
 
 INSTANTIATE_TEST_SUITE_P(QFT, QFT,
-                         testing::Range((unsigned short)0, (unsigned short)(QFT_MAX_QUBITS + 1), 3),
+                         testing::Range(static_cast<dd::QubitCount>(0), static_cast<dd::QubitCount>(QFT_MAX_QUBITS + 1), 3),
                          [](const testing::TestParamInfo<QFT::ParamType>& info) {
-			unsigned short nqubits = info.param;
+			dd::QubitCount nqubits = info.param;
 			std::stringstream ss{};
-			ss << nqubits;
+			ss << static_cast<std::size_t>(nqubits);
 			if (nqubits == 1) {
 				ss << "_qubit";
 			} else {
@@ -61,18 +66,15 @@ INSTANTIATE_TEST_SUITE_P(QFT, QFT,
 			return ss.str(); });
 
 TEST_P(QFT, Functionality) {
-    nqubits = GetParam();
-
     // there should be no error constructing the circuit
     ASSERT_NO_THROW({ qc = std::make_unique<qc::QFT>(nqubits); });
 
     // there should be no error building the functionality
-    ASSERT_NO_THROW({ e = qc->buildFunctionality(dd); });
+    ASSERT_NO_THROW({ func = qc->buildFunctionality(dd); });
 
     qc->printStatistics(std::cout);
-
     // QFT DD should consist of 2^n nodes
-    ASSERT_EQ(dd->size(e), std::pow(2, nqubits));
+    ASSERT_EQ(dd->size(func), std::pow(2, nqubits));
 
     // Force garbage collection of compute table and complex table
     dd->garbageCollect(true);
@@ -81,67 +83,63 @@ TEST_P(QFT, Functionality) {
     // since only positive real values are stored in the complex table
     // this number has to be divided by 4
     // the (+3) accounts for the fact that the table is pre-filled with some values {0,0.5,sqrt(0.5)}
-    ASSERT_EQ(dd->cn.count, static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)) + 3);
+    ASSERT_EQ(dd->cn.complexTable.getCount(), static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)) + 3);
 
     // top edge weight should equal sqrt(0.5)^n
-    EXPECT_NEAR(CN::val(e.w.r), static_cast<fp>(std::pow(1.L / std::sqrt(2.L), nqubits)), CN::TOLERANCE);
+    EXPECT_NEAR(func.w.r->val(), static_cast<dd::fp>(std::pow(1.L / std::sqrt(2.L), nqubits)), dd->cn.complexTable.tolerance());
 
-    // first row and first column should consist only of 1's
+    // first row and first column should consist only of (1/sqrt(2))**nqubits
     for (unsigned long long i = 0; i < std::pow(static_cast<long double>(2), nqubits); ++i) {
-        auto c = qc->getEntry(dd, e, 0, i);
-        EXPECT_NEAR(CN::val(c.r), 1, CN::TOLERANCE);
-        EXPECT_NEAR(CN::val(c.i), 0, CN::TOLERANCE);
-        c = qc->getEntry(dd, e, i, 0);
-        EXPECT_NEAR(CN::val(c.r), 1, CN::TOLERANCE);
-        EXPECT_NEAR(CN::val(c.i), 0, CN::TOLERANCE);
+        auto c = dd->getValueByPath(func, 0, i);
+        EXPECT_NEAR(c.r, static_cast<dd::fp>(std::pow(1.L / std::sqrt(2.L), nqubits)), dd->cn.complexTable.tolerance());
+        EXPECT_NEAR(c.i, 0, dd->cn.complexTable.tolerance());
+        c = dd->getValueByPath(func, i, 0);
+        EXPECT_NEAR(c.r, static_cast<dd::fp>(std::pow(1.L / std::sqrt(2.L), nqubits)), dd->cn.complexTable.tolerance());
+        EXPECT_NEAR(c.i, 0, dd->cn.complexTable.tolerance());
     }
 }
 
 TEST_P(QFT, Simulation) {
-    nqubits = GetParam();
-
     // there should be no error constructing the circuit
     ASSERT_NO_THROW({ qc = std::make_unique<qc::QFT>(nqubits); });
 
     // there should be no error building the functionality
     ASSERT_NO_THROW({
-        dd::Edge in = dd->makeZeroState(nqubits);
-        e           = qc->simulate(in, dd);
+        auto in = dd->makeZeroState(nqubits);
+        sim     = qc->simulate(in, dd);
     });
     qc->printStatistics(std::cout);
 
     // QFT DD |0...0> sim should consist of n nodes
-    ASSERT_EQ(dd->size(e), nqubits + 1);
+    ASSERT_EQ(dd->size(sim), nqubits + 1);
 
     // Force garbage collection of compute table and complex table
     dd->garbageCollect(true);
 
-    // top edge weight should equal sqrt(0.5)^n
-    EXPECT_NEAR(CN::val(e.w.r), 1, CN::TOLERANCE);
-    EXPECT_NEAR(CN::val(e.w.i), 0, CN::TOLERANCE);
+    // top edge weight should equal 1
+    EXPECT_NEAR(sim.w.r->val(), 1, dd->cn.complexTable.tolerance());
+    EXPECT_NEAR(sim.w.i->val(), 0, dd->cn.complexTable.tolerance());
 
-    // first column should consist only of 1's
+    // first column should consist only of sqrt(0.5)^n's
     for (unsigned long long i = 0; i < std::pow(static_cast<long double>(2), nqubits); ++i) {
-        auto c = qc->getEntry(dd, e, i, 0);
-        EXPECT_NEAR(CN::val(c.r), static_cast<fp>(std::pow(1.L / std::sqrt(2.L), nqubits)), CN::TOLERANCE);
-        EXPECT_NEAR(CN::val(c.i), 0, CN::TOLERANCE);
+        auto c = dd->getValueByPath(sim, i);
+        EXPECT_NEAR(c.r, static_cast<dd::fp>(std::pow(1.L / std::sqrt(2.L), nqubits)), dd->cn.complexTable.tolerance());
+        EXPECT_NEAR(c.i, 0, dd->cn.complexTable.tolerance());
     }
 }
 
 TEST_P(QFT, FunctionalityRecursiveEquality) {
-    nqubits = GetParam();
-
     // there should be no error constructing the circuit
     ASSERT_NO_THROW({ qc = std::make_unique<qc::QFT>(nqubits); });
     std::cout << *qc << std::endl;
 
     // there should be no error building the functionality recursively
-    ASSERT_NO_THROW({ e = qc->buildFunctionalityRecursive(dd); });
+    ASSERT_NO_THROW({ func = qc->buildFunctionalityRecursive(dd); });
 
     // there should be no error building the functionality regularly
-    dd::Edge f{};
-    ASSERT_NO_THROW({ f = qc->buildFunctionality(dd); });
+    qc::MatrixDD funcRec{};
+    ASSERT_NO_THROW({ funcRec = qc->buildFunctionality(dd); });
 
-    ASSERT_TRUE(dd->equals(e, f));
-    dd->decRef(f);
+    ASSERT_EQ(func, funcRec);
+    dd->decRef(funcRec);
 }

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -86,7 +86,7 @@ TEST_P(QFT, Functionality) {
     ASSERT_EQ(dd->cn.complexTable.getCount(), static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)) + 3);
 
     // top edge weight should equal sqrt(0.5)^n
-    EXPECT_NEAR(func.w.r->val(), static_cast<dd::fp>(std::pow(1.L / std::sqrt(2.L), nqubits)), dd->cn.complexTable.tolerance());
+    EXPECT_NEAR(dd::ComplexTable<>::Entry::val(func.w.r), static_cast<dd::fp>(std::pow(1.L / std::sqrt(2.L), nqubits)), dd->cn.complexTable.tolerance());
 
     // first row and first column should consist only of (1/sqrt(2))**nqubits
     for (unsigned long long i = 0; i < std::pow(static_cast<long double>(2), nqubits); ++i) {
@@ -117,8 +117,8 @@ TEST_P(QFT, Simulation) {
     dd->garbageCollect(true);
 
     // top edge weight should equal 1
-    EXPECT_NEAR(sim.w.r->val(), 1, dd->cn.complexTable.tolerance());
-    EXPECT_NEAR(sim.w.i->val(), 0, dd->cn.complexTable.tolerance());
+    EXPECT_NEAR(dd::ComplexTable<>::Entry::val(sim.w.r), 1, dd->cn.complexTable.tolerance());
+    EXPECT_NEAR(dd::ComplexTable<>::Entry::val(sim.w.i), 0, dd->cn.complexTable.tolerance());
 
     // first column should consist only of sqrt(0.5)^n's
     for (unsigned long long i = 0; i < std::pow(static_cast<long double>(2), nqubits); ++i) {

--- a/test/algorithms/test_random_clifford.cpp
+++ b/test/algorithms/test_random_clifford.cpp
@@ -8,26 +8,26 @@
 #include "gtest/gtest.h"
 #include <string>
 
-class RandomClifford: public testing::TestWithParam<unsigned short> {
+class RandomClifford: public testing::TestWithParam<dd::QubitCount> {
 protected:
     void TearDown() override {}
     void SetUp() override {}
 };
 
 INSTANTIATE_TEST_SUITE_P(RandomClifford, RandomClifford,
-                         testing::Range((unsigned short)1, (unsigned short)9),
+                         testing::Range(static_cast<dd::QubitCount>(1), static_cast<dd::QubitCount>(9)),
                          [](const testing::TestParamInfo<RandomClifford::ParamType>& info) {
                              // Generate names for test cases
-                             unsigned short    nqubits = info.param;
+                             dd::QubitCount   nqubits = info.param;
                              std::stringstream ss{};
-                             ss << nqubits << "_qubits";
+                             ss << static_cast<std::size_t>(nqubits) << "_qubits";
                              return ss.str();
                          });
 
 TEST_P(RandomClifford, simulate) {
-    const unsigned short nq = GetParam();
+    const dd::QubitCount nq = GetParam();
 
-    auto dd = std::make_unique<dd::Package>();
+    auto dd = std::make_unique<dd::Package>(nq);
     auto qc = qc::RandomCliffordCircuit(nq, nq * nq);
     auto in = dd->makeZeroState(nq);
 
@@ -37,9 +37,9 @@ TEST_P(RandomClifford, simulate) {
 }
 
 TEST_P(RandomClifford, buildFunctionality) {
-    const unsigned short nq = GetParam();
+    const dd::QubitCount nq = GetParam();
 
-    auto dd = std::make_unique<dd::Package>();
+    auto dd = std::make_unique<dd::Package>(nq);
     auto qc = qc::RandomCliffordCircuit(nq, nq * nq);
     std::cout << qc << std::endl;
     ASSERT_NO_THROW({ qc.buildFunctionality(dd); });

--- a/test/algorithms/test_random_clifford.cpp
+++ b/test/algorithms/test_random_clifford.cpp
@@ -18,7 +18,7 @@ INSTANTIATE_TEST_SUITE_P(RandomClifford, RandomClifford,
                          testing::Range(static_cast<dd::QubitCount>(1), static_cast<dd::QubitCount>(9)),
                          [](const testing::TestParamInfo<RandomClifford::ParamType>& info) {
                              // Generate names for test cases
-                             dd::QubitCount   nqubits = info.param;
+                             dd::QubitCount    nqubits = info.param;
                              std::stringstream ss{};
                              ss << static_cast<std::size_t>(nqubits) << "_qubits";
                              return ss.str();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -28,7 +28,7 @@ int main() {
     n = 2;
     qc::Grover grover(n); // generates Grover's algorithm for a random n-bit oracle
 
-    auto dd            = make_unique<dd::Package>(); // create an instance of the DD package
+    auto dd            = make_unique<dd::Package>(n + 1); // create an instance of the DD package
     auto functionality = qft.buildFunctionality(dd);
     dd->printMatrix(functionality);
     dd::export2Dot(functionality, "functionality.dot");

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -9,7 +9,6 @@
 #include "dd/Export.hpp"
 
 using namespace std;
-using namespace chrono;
 
 int main() {
     std::string            filename = "./circuits/test.real";

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -4,9 +4,9 @@
  */
 
 #include "QuantumComputation.hpp"
-#include "algorithms/GoogleRandomCircuitSampling.hpp"
 #include "algorithms/Grover.hpp"
 #include "algorithms/QFT.hpp"
+#include "dd/Export.hpp"
 
 using namespace std;
 using namespace chrono;
@@ -22,21 +22,22 @@ int main() {
     filename = "./circuits/grcs/bris_4_40_9_v2.txt";
     qc.import(filename);
 
-    unsigned short n = 3;
+    dd::QubitCount n = 3;
     qc::QFT        qft(n); // generates the QFT for n qubits
+    std::cout << qft << std::endl;
 
     n = 2;
     qc::Grover grover(n); // generates Grover's algorithm for a random n-bit oracle
 
     auto dd            = make_unique<dd::Package>(); // create an instance of the DD package
     auto functionality = qft.buildFunctionality(dd);
-    qft.printMatrix(dd, functionality, std::cout);
+    dd->printMatrix(functionality);
     dd::export2Dot(functionality, "functionality.dot");
     std::cout << std::endl;
 
     auto initial_state = dd->makeZeroState(n + 1); // create initial state |0...0>
     auto state_vector  = grover.simulate(initial_state, dd);
-    grover.printVector(dd, state_vector, std::cout);
+    dd->printVector(state_vector);
     dd::export2Dot(state_vector, "state_vector.dot", true);
     std::cout << std::endl
               << grover << std::endl;

--- a/test/unittests/test_ddfunctionality.cpp
+++ b/test/unittests/test_ddfunctionality.cpp
@@ -167,4 +167,19 @@ TEST_F(DDFunctionality, non_unitary) {
     EXPECT_THROW(op.getInverseDD(dd), qc::QFRException);
     EXPECT_THROW(op.getDD(dd, dummy_map), qc::QFRException);
     EXPECT_THROW(op.getInverseDD(dd, dummy_map), qc::QFRException);
+    for (dd::Qubit i = 0; i < static_cast<dd::Qubit>(nqubits); ++i) {
+        EXPECT_TRUE(op.actsOn(i));
+    }
+
+    for (dd::Qubit i = 0; i < static_cast<dd::Qubit>(nqubits); ++i) {
+        dummy_map[i] = i;
+    }
+    auto barrier = qc::NonUnitaryOperation(nqubits, {0, 1, 2, 3}, qc::OpType::Barrier);
+    EXPECT_EQ(barrier.getDD(dd), dd->makeIdent(nqubits));
+    EXPECT_EQ(barrier.getInverseDD(dd), dd->makeIdent(nqubits));
+    EXPECT_EQ(barrier.getDD(dd, dummy_map), dd->makeIdent(nqubits));
+    EXPECT_EQ(barrier.getInverseDD(dd, dummy_map), dd->makeIdent(nqubits));
+    for (dd::Qubit i = 0; i < static_cast<dd::Qubit>(nqubits); ++i) {
+        EXPECT_FALSE(barrier.actsOn(i));
+    }
 }

--- a/test/unittests/test_ddfunctionality.cpp
+++ b/test/unittests/test_ddfunctionality.cpp
@@ -163,40 +163,8 @@ TEST_F(DDFunctionality, non_unitary) {
     auto                   dummy_map = Permutation{};
     auto                   op        = qc::NonUnitaryOperation(nqubits, {0, 1, 2, 3}, {0, 1, 2, 3});
     EXPECT_FALSE(op.isUnitary());
-    try {
-        op.getDD(dd);
-        FAIL() << "Nothing thrown. Expected qc::QFRException";
-    } catch (qc::QFRException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qc::QFRException";
-    }
-    try {
-        op.getInverseDD(dd);
-        FAIL() << "Nothing thrown. Expected qc::QFRException";
-    } catch (qc::QFRException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qc::QFRException";
-    }
-    try {
-        op.getDD(dd, dummy_map);
-        FAIL() << "Nothing thrown. Expected qc::QFRException";
-    } catch (qc::QFRException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qc::QFRException";
-    }
-    try {
-        op.getInverseDD(dd, dummy_map);
-        FAIL() << "Nothing thrown. Expected qc::QFRException";
-    } catch (qc::QFRException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qc::QFRException";
-    }
+    EXPECT_THROW(op.getDD(dd), qc::QFRException);
+    EXPECT_THROW(op.getInverseDD(dd), qc::QFRException);
+    EXPECT_THROW(op.getDD(dd, dummy_map), qc::QFRException);
+    EXPECT_THROW(op.getInverseDD(dd, dummy_map), qc::QFRException);
 }

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -20,7 +20,7 @@ protected:
         qc = std::make_unique<qc::QuantumComputation>();
     }
 
-    unsigned short                          nqubits = 0;
+    dd::QubitCount                          nqubits = 0;
     unsigned int                            seed    = 0;
     std::string                             output  = "tmp.txt";
     std::string                             output2 = "tmp2.txt";

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -250,3 +250,29 @@ TEST_F(IO, classic_controlled) {
     EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM););
     std::cout << *qc << std::endl;
 }
+
+TEST_F(IO, changePermutation) {
+    std::stringstream ss{};
+    ss << "// o 1 0\n"
+       << "OPENQASM 2.0;"
+       << "include \"qelib1.inc\";"
+       << "qreg q[2];"
+       << "x q[0];"
+       << std::endl;
+    qc->import(ss, qc::OpenQASM);
+    auto dd  = std::make_unique<dd::Package>();
+    auto sim = qc->simulate(dd->makeZeroState(qc->getNqubits()), dd);
+    EXPECT_TRUE(sim.p->e[0].isZeroTerminal());
+    EXPECT_TRUE(sim.p->e[1].w.approximatelyOne());
+    EXPECT_TRUE(sim.p->e[1].p->e[1].isZeroTerminal());
+    EXPECT_TRUE(sim.p->e[1].p->e[0].w.approximatelyOne());
+    auto func = qc->buildFunctionality(dd);
+    EXPECT_FALSE(func.p->e[0].isZeroTerminal());
+    EXPECT_FALSE(func.p->e[1].isZeroTerminal());
+    EXPECT_FALSE(func.p->e[2].isZeroTerminal());
+    EXPECT_FALSE(func.p->e[3].isZeroTerminal());
+    EXPECT_TRUE(func.p->e[0].p->e[1].w.approximatelyOne());
+    EXPECT_TRUE(func.p->e[1].p->e[3].w.approximatelyOne());
+    EXPECT_TRUE(func.p->e[2].p->e[0].w.approximatelyOne());
+    EXPECT_TRUE(func.p->e[3].p->e[2].w.approximatelyOne());
+}

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -88,15 +88,7 @@ TEST_F(IO, importFromString) {
 TEST_F(IO, controlled_op_acting_on_whole_register) {
     std::string       circuit_qasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncx q,q[1];\n";
     std::stringstream ss{circuit_qasm};
-    try {
-        qc->import(ss, qc::OpenQASM);
-        FAIL() << "Nothing thrown. Expected qasm::QASMParserException";
-    } catch (qasm::QASMParserException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qasm::QASMParserException";
-    }
+    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, invalid_real_header) {
@@ -114,57 +106,25 @@ TEST_F(IO, invalid_real_command) {
 TEST_F(IO, insufficient_registers_qelib) {
     std::string       circuit_qasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncx q[0];\n";
     std::stringstream ss{circuit_qasm};
-    try {
-        qc->import(ss, qc::OpenQASM);
-        FAIL() << "Nothing thrown. Expected qasm::QASMParserException";
-    } catch (qasm::QASMParserException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qasm::QASMParserException";
-    }
+    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, insufficient_registers_enhanced_qelib) {
     std::string       circuit_qasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[4];\ncccz q[0], q[1], q[2];\n";
     std::stringstream ss{circuit_qasm};
-    try {
-        qc->import(ss, qc::OpenQASM);
-        FAIL() << "Nothing thrown. Expected qasm::QASMParserException";
-    } catch (qasm::QASMParserException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qasm::QASMParserException";
-    }
+    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, superfluous_registers_qelib) {
     std::string       circuit_qasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[3];\ncx q[0], q[1], q[2];\n";
     std::stringstream ss{circuit_qasm};
-    try {
-        qc->import(ss, qc::OpenQASM);
-        FAIL() << "Nothing thrown. Expected qasm::QASMParserException";
-    } catch (qasm::QASMParserException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qasm::QASMParserException";
-    }
+    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, superfluous_registers_enhanced_qelib) {
     std::string       circuit_qasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[5];\ncccz q[0], q[1], q[2], q[3], q[4];\n";
     std::stringstream ss{circuit_qasm};
-    try {
-        qc->import(ss, qc::OpenQASM);
-        FAIL() << "Nothing thrown. Expected qasm::QASMParserException";
-    } catch (qasm::QASMParserException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qasm::QASMParserException";
-    }
+    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, dump_negative_control) {
@@ -245,15 +205,7 @@ TEST_F(IO, qiskit_mcx_duplicate_qubit) {
        << "qreg anc[1];"
        << "mcx_vchain q[0], q[0], q[2], q[3], anc[0];"
        << std::endl;
-    try {
-        qc->import(ss, qc::OpenQASM);
-        FAIL() << "Nothing thrown. Expected qasm::QASMParserException";
-    } catch (qasm::QASMParserException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qasm::QASMParserException";
-    }
+    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, qiskit_mcx_qubit_register) {
@@ -264,15 +216,7 @@ TEST_F(IO, qiskit_mcx_qubit_register) {
        << "qreg anc[1];"
        << "mcx_vchain q, q[0], q[2], q[3], anc[0];"
        << std::endl;
-    try {
-        qc->import(ss, qc::OpenQASM);
-        FAIL() << "Nothing thrown. Expected qasm::QASMParserException";
-    } catch (qasm::QASMParserException const& err) {
-        std::cout << err.what() << std::endl;
-        SUCCEED();
-    } catch (...) {
-        FAIL() << "Expected qasm::QASMParserException";
-    }
+    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, tfc_input) {

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -28,13 +28,13 @@ protected:
         dist = std::uniform_real_distribution<dd::fp>(0.0, 2 * dd::PI);
     }
 
-    std::unique_ptr<dd::Package>       dd;
-    std::mt19937_64                    mt;
+    std::unique_ptr<dd::Package>           dd;
+    std::mt19937_64                        mt;
     std::uniform_real_distribution<dd::fp> dist;
 };
 
 TEST_F(QFRFunctionality, fuse_cx_to_swap) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::X);
     qc.emplace_back<StandardOperation>(nqubits, 1_pc, 0, qc::X);
@@ -49,7 +49,7 @@ TEST_F(QFRFunctionality, fuse_cx_to_swap) {
 }
 
 TEST_F(QFRFunctionality, replace_cx_to_swap_at_end) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::X);
     qc.emplace_back<StandardOperation>(nqubits, 1_pc, 0, qc::X);
@@ -71,7 +71,7 @@ TEST_F(QFRFunctionality, replace_cx_to_swap_at_end) {
 }
 
 TEST_F(QFRFunctionality, replace_cx_to_swap) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::X);
     qc.emplace_back<StandardOperation>(nqubits, 1_pc, 0, qc::X);
@@ -94,7 +94,7 @@ TEST_F(QFRFunctionality, replace_cx_to_swap) {
 }
 
 TEST_F(QFRFunctionality, remove_trailing_idle_qubits) {
-    QubitCount nqubits = 4;
+    QubitCount         nqubits = 4;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     qc.emplace_back<StandardOperation>(nqubits, 2, qc::X);
@@ -122,7 +122,7 @@ TEST_F(QFRFunctionality, remove_trailing_idle_qubits) {
 }
 
 TEST_F(QFRFunctionality, ancillary_qubit_at_end) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     qc.addAncillaryRegister(1);
@@ -182,7 +182,7 @@ TEST_F(QFRFunctionality, ancillary_qubit_at_end) {
 }
 
 TEST_F(QFRFunctionality, ancillary_qubit_remove_middle) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     qc.addAncillaryRegister(3);
@@ -196,7 +196,7 @@ TEST_F(QFRFunctionality, ancillary_qubit_remove_middle) {
 }
 
 TEST_F(QFRFunctionality, split_qreg) {
-    QubitCount nqubits = 3;
+    QubitCount         nqubits = 3;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     auto p = qc.removeQubit(1);
@@ -209,7 +209,7 @@ TEST_F(QFRFunctionality, split_qreg) {
 }
 
 TEST_F(QFRFunctionality, FuseTwoSingleQubitGates) {
-    QubitCount nqubits = 1;
+    QubitCount         nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
@@ -225,7 +225,7 @@ TEST_F(QFRFunctionality, FuseTwoSingleQubitGates) {
 }
 
 TEST_F(QFRFunctionality, FuseThreeSingleQubitGates) {
-    QubitCount nqubits = 1;
+    QubitCount         nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
@@ -243,7 +243,7 @@ TEST_F(QFRFunctionality, FuseThreeSingleQubitGates) {
 }
 
 TEST_F(QFRFunctionality, FuseNoSingleQubitGates) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
     qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::X);
@@ -260,7 +260,7 @@ TEST_F(QFRFunctionality, FuseNoSingleQubitGates) {
 }
 
 TEST_F(QFRFunctionality, FuseSingleQubitGatesAcrossOtherGates) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
     qc.emplace_back<StandardOperation>(nqubits, 1, qc::Z);
@@ -313,7 +313,7 @@ TEST_F(QFRFunctionality, StripIdleAndDump) {
 }
 
 TEST_F(QFRFunctionality, CollapseCompoundOperationToStandard) {
-    QubitCount nqubits = 1;
+    QubitCount         nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::I);
@@ -327,7 +327,7 @@ TEST_F(QFRFunctionality, CollapseCompoundOperationToStandard) {
 }
 
 TEST_F(QFRFunctionality, eliminateCompoundOperation) {
-    QubitCount nqubits = 1;
+    QubitCount         nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::I);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::I);
@@ -341,7 +341,7 @@ TEST_F(QFRFunctionality, eliminateCompoundOperation) {
 }
 
 TEST_F(QFRFunctionality, eliminateInverseInCompoundOperation) {
-    QubitCount nqubits = 1;
+    QubitCount         nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, S);
     qc.emplace_back<StandardOperation>(nqubits, 0, Sdag);
@@ -355,7 +355,7 @@ TEST_F(QFRFunctionality, eliminateInverseInCompoundOperation) {
 }
 
 TEST_F(QFRFunctionality, unknownInverseInCompoundOperation) {
-    QubitCount nqubits = 1;
+    QubitCount         nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, Phase, 1.);
     qc.emplace_back<StandardOperation>(nqubits, 0, Phase, -1.);
@@ -368,7 +368,7 @@ TEST_F(QFRFunctionality, unknownInverseInCompoundOperation) {
 }
 
 TEST_F(QFRFunctionality, removeDiagonalSingleQubitBeforeMeasure) {
-    QubitCount nqubits = 1;
+    QubitCount         nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::Z);
     qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
@@ -382,7 +382,7 @@ TEST_F(QFRFunctionality, removeDiagonalSingleQubitBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeDiagonalCompoundOpBeforeMeasure) {
-    QubitCount nqubits = 1;
+    QubitCount         nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::Z);
     qc.emplace_back<StandardOperation>(nqubits, 0, T);
@@ -398,7 +398,7 @@ TEST_F(QFRFunctionality, removeDiagonalCompoundOpBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeDiagonalTwoQubitGateBeforeMeasure) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::Z);
     qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0, 1}, std::vector<std::size_t>{0, 1});
@@ -412,7 +412,7 @@ TEST_F(QFRFunctionality, removeDiagonalTwoQubitGateBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, leaveGateBeforeMeasure) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::Z);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
@@ -426,7 +426,7 @@ TEST_F(QFRFunctionality, leaveGateBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeComplexGateBeforeMeasure) {
-    QubitCount nqubits = 4;
+    QubitCount         nqubits = 4;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::Z);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
@@ -448,7 +448,7 @@ TEST_F(QFRFunctionality, removeComplexGateBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeSimpleCompoundOpBeforeMeasure) {
-    QubitCount nqubits = 1;
+    QubitCount         nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::T);
@@ -463,7 +463,7 @@ TEST_F(QFRFunctionality, removeSimpleCompoundOpBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removePartOfCompoundOpBeforeMeasure) {
-    QubitCount nqubits = 1;
+    QubitCount         nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::T);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
@@ -479,7 +479,7 @@ TEST_F(QFRFunctionality, removePartOfCompoundOpBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, decomposeSWAPsUndirectedArchitecture) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, Controls{}, 0, 1, SWAP);
     std::cout << "-----------------------------" << std::endl;
@@ -510,7 +510,7 @@ TEST_F(QFRFunctionality, decomposeSWAPsUndirectedArchitecture) {
     });
 }
 TEST_F(QFRFunctionality, decomposeSWAPsDirectedArchitecture) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, Controls{}, 0, 1, SWAP);
     std::cout << "-----------------------------" << std::endl;
@@ -566,7 +566,7 @@ TEST_F(QFRFunctionality, decomposeSWAPsDirectedArchitecture) {
 }
 
 TEST_F(QFRFunctionality, decomposeSWAPsCompound) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<qc::StandardOperation>(nqubits, 0, qc::X); //We need something to replace with compound
     auto gate = std::make_unique<qc::CompoundOperation>(nqubits);
@@ -585,7 +585,7 @@ TEST_F(QFRFunctionality, decomposeSWAPsCompound) {
     EXPECT_EQ(dynamic_cast<qc::CompoundOperation*>(it->get())->size(), 9);
 }
 TEST_F(QFRFunctionality, decomposeSWAPsCompoundDirected) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<qc::StandardOperation>(nqubits, 0, qc::X); //We need something to replace with compound
     auto gate = std::make_unique<qc::CompoundOperation>(nqubits);
@@ -605,7 +605,7 @@ TEST_F(QFRFunctionality, decomposeSWAPsCompoundDirected) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurements) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
     qc.emplace_back<StandardOperation>(nqubits, 1, qc::H);
@@ -633,7 +633,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurements) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsTwoQubitMeasurement) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
     qc.emplace_back<StandardOperation>(nqubits, 1, qc::H);
@@ -660,7 +660,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsTwoQubitMeasurement) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsCompound) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<qc::StandardOperation>(nqubits, 0, qc::X); //We need something to replace with compound
     auto gate = std::make_unique<qc::CompoundOperation>(nqubits);
@@ -687,7 +687,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsCompound) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundDegraded) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<qc::StandardOperation>(nqubits, 0, qc::X); //We need something to replace with compound
     auto gate = std::make_unique<qc::CompoundOperation>(nqubits);
@@ -715,7 +715,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundDegraded) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundEmpty) {
-    QubitCount nqubits = 2;
+    QubitCount         nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<qc::StandardOperation>(nqubits, 0, qc::X); //We need something to replace with compound
     auto gate = std::make_unique<qc::CompoundOperation>(nqubits);

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -10,36 +10,35 @@
 #include <random>
 
 using namespace qc;
+using namespace dd;
 
-class QFRFunctionality: public testing::TestWithParam<unsigned short> {
+class QFRFunctionality: public testing::TestWithParam<dd::QubitCount> {
 protected:
     void TearDown() override {
     }
 
     void SetUp() override {
-        dd = std::make_unique<dd::Package>();
-        line.fill(qc::LINE_DEFAULT);
+        dd = std::make_unique<dd::Package>(5);
 
         std::array<std::mt19937_64::result_type, std::mt19937_64::state_size> random_data{};
         std::random_device                                                    rd;
         std::generate(begin(random_data), end(random_data), [&]() { return rd(); });
         std::seed_seq seeds(begin(random_data), end(random_data));
         mt.seed(seeds);
-        dist = std::uniform_real_distribution<fp>(0.0, 2 * qc::PI);
+        dist = std::uniform_real_distribution<dd::fp>(0.0, 2 * dd::PI);
     }
 
-    std::array<short, qc::MAX_QUBITS>  line{};
     std::unique_ptr<dd::Package>       dd;
     std::mt19937_64                    mt;
-    std::uniform_real_distribution<fp> dist;
+    std::uniform_real_distribution<dd::fp> dist;
 };
 
 TEST_F(QFRFunctionality, fuse_cx_to_swap) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, Control(0), 1, X);
-    qc.emplace_back<StandardOperation>(nqubits, Control(1), 0, X);
-    qc.emplace_back<StandardOperation>(nqubits, Control(0), 1, X);
+    qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 1_pc, 0, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::X);
     CircuitOptimizer::swapReconstruction(qc);
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>((qc.begin()->get()));
@@ -50,10 +49,10 @@ TEST_F(QFRFunctionality, fuse_cx_to_swap) {
 }
 
 TEST_F(QFRFunctionality, replace_cx_to_swap_at_end) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, Control(0), 1, X);
-    qc.emplace_back<StandardOperation>(nqubits, Control(1), 0, X);
+    qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 1_pc, 0, qc::X);
     CircuitOptimizer::swapReconstruction(qc);
     auto it = qc.begin();
     ASSERT_NO_THROW({
@@ -65,18 +64,18 @@ TEST_F(QFRFunctionality, replace_cx_to_swap_at_end) {
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), X);
-        EXPECT_EQ(op->getControls().at(0).qubit, 0);
+        EXPECT_EQ(op->getType(), qc::X);
+        EXPECT_EQ(op->getControls().begin()->qubit, 0);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
 }
 
 TEST_F(QFRFunctionality, replace_cx_to_swap) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, Control(0), 1, X);
-    qc.emplace_back<StandardOperation>(nqubits, Control(1), 0, X);
-    qc.emplace_back<StandardOperation>(nqubits, 0, H);
+    qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 1_pc, 0, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
     CircuitOptimizer::swapReconstruction(qc);
     auto it = qc.begin();
     ASSERT_NO_THROW({
@@ -88,19 +87,19 @@ TEST_F(QFRFunctionality, replace_cx_to_swap) {
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), X);
-        EXPECT_EQ(op->getControls().at(0).qubit, 0);
+        EXPECT_EQ(op->getType(), qc::X);
+        EXPECT_EQ(op->getControls().begin()->qubit, 0);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
 }
 
 TEST_F(QFRFunctionality, remove_trailing_idle_qubits) {
-    unsigned short     nqubits = 4;
+    QubitCount nqubits = 4;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
-    qc.emplace_back<StandardOperation>(nqubits, 2, X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 2, qc::X);
     std::cout << qc;
-    qc::QuantumComputation::printPermutationMap(qc.outputPermutation);
+    qc::QuantumComputation::printPermutation(qc.outputPermutation);
     qc.printRegisters();
 
     qc.outputPermutation.erase(1);
@@ -109,13 +108,13 @@ TEST_F(QFRFunctionality, remove_trailing_idle_qubits) {
     qc.stripIdleQubits();
     EXPECT_EQ(qc.getNqubits(), 2);
     std::cout << qc;
-    qc::QuantumComputation::printPermutationMap(qc.outputPermutation);
+    qc::QuantumComputation::printPermutation(qc.outputPermutation);
     qc.printRegisters();
 
     qc.pop_back();
     qc.outputPermutation.erase(2);
     std::cout << qc;
-    qc::QuantumComputation::printPermutationMap(qc.outputPermutation);
+    qc::QuantumComputation::printPermutation(qc.outputPermutation);
     qc.printRegisters();
 
     qc.stripIdleQubits();
@@ -123,24 +122,24 @@ TEST_F(QFRFunctionality, remove_trailing_idle_qubits) {
 }
 
 TEST_F(QFRFunctionality, ancillary_qubit_at_end) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     qc.addAncillaryRegister(1);
     EXPECT_EQ(qc.getNancillae(), 1);
     EXPECT_EQ(qc.getNqubitsWithoutAncillae(), nqubits);
     EXPECT_EQ(qc.getNqubits(), 3);
-    qc.emplace_back<StandardOperation>(nqubits, 2, X);
+    qc.emplace_back<StandardOperation>(nqubits, 2, qc::X);
     auto e = qc.createInitialMatrix(dd);
-    EXPECT_TRUE(dd->equals(e.p->e[0], dd->makeIdent(nqubits)));
-    EXPECT_TRUE(dd->equals(e.p->e[1], dd->DDzero));
-    EXPECT_TRUE(dd->equals(e.p->e[2], dd->DDzero));
-    EXPECT_TRUE(dd->equals(e.p->e[3], dd->DDzero));
+    EXPECT_EQ(e.p->e[0], dd->makeIdent(nqubits));
+    EXPECT_EQ(e.p->e[1], MatrixDD::zero);
+    EXPECT_EQ(e.p->e[2], MatrixDD::zero);
+    EXPECT_EQ(e.p->e[3], MatrixDD::zero);
     auto f = dd->makeIdent(nqubits + 1);
     dd->incRef(f);
-    f = qc.reduceAncillae(f, dd);
-    f = qc.reduceGarbage(f, dd);
-    EXPECT_TRUE(dd->equals(e, f));
+    f = dd->reduceAncillae(f, qc.ancillary);
+    f = dd->reduceGarbage(f, qc.garbage);
+    EXPECT_EQ(e, f);
     qc.printRegisters();
     auto p = qc.removeQubit(2);
     EXPECT_EQ(p.first, nqubits);
@@ -183,9 +182,9 @@ TEST_F(QFRFunctionality, ancillary_qubit_at_end) {
 }
 
 TEST_F(QFRFunctionality, ancillary_qubit_remove_middle) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     qc.addAncillaryRegister(3);
     auto p = qc.removeQubit(3);
     EXPECT_EQ(p.first, 3);
@@ -197,9 +196,9 @@ TEST_F(QFRFunctionality, ancillary_qubit_remove_middle) {
 }
 
 TEST_F(QFRFunctionality, split_qreg) {
-    unsigned short     nqubits = 3;
+    QubitCount nqubits = 3;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
     auto p = qc.removeQubit(1);
     EXPECT_EQ(p.first, 1);
     EXPECT_EQ(p.second, 1);
@@ -210,10 +209,10 @@ TEST_F(QFRFunctionality, split_qreg) {
 }
 
 TEST_F(QFRFunctionality, FuseTwoSingleQubitGates) {
-    unsigned short     nqubits = 1;
+    QubitCount nqubits = 1;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
-    qc.emplace_back<StandardOperation>(nqubits, 0, H);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
 
     qc.print(std::cout);
     dd::Edge e = qc.buildFunctionality(dd);
@@ -222,15 +221,15 @@ TEST_F(QFRFunctionality, FuseTwoSingleQubitGates) {
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     EXPECT_EQ(qc.getNops(), 1);
-    EXPECT_TRUE(dd::Package::equals(e, f));
+    EXPECT_EQ(e, f);
 }
 
 TEST_F(QFRFunctionality, FuseThreeSingleQubitGates) {
-    unsigned short     nqubits = 1;
+    QubitCount nqubits = 1;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
-    qc.emplace_back<StandardOperation>(nqubits, 0, H);
-    qc.emplace_back<StandardOperation>(nqubits, 0, Y);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::Y);
 
     dd::Edge e = qc.buildFunctionality(dd);
     std::cout << "-----------------------------" << std::endl;
@@ -240,15 +239,15 @@ TEST_F(QFRFunctionality, FuseThreeSingleQubitGates) {
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     EXPECT_EQ(qc.getNops(), 1);
-    EXPECT_TRUE(dd::Package::equals(e, f));
+    EXPECT_EQ(e, f);
 }
 
 TEST_F(QFRFunctionality, FuseNoSingleQubitGates) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, H);
-    qc.emplace_back<StandardOperation>(nqubits, qc::Control(0), 1, X);
-    qc.emplace_back<StandardOperation>(nqubits, 0, Y);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
+    qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::Y);
     dd::Edge e = qc.buildFunctionality(dd);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
@@ -257,15 +256,15 @@ TEST_F(QFRFunctionality, FuseNoSingleQubitGates) {
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     EXPECT_EQ(qc.getNops(), 3);
-    EXPECT_TRUE(dd::Package::equals(e, f));
+    EXPECT_EQ(e, f);
 }
 
 TEST_F(QFRFunctionality, FuseSingleQubitGatesAcrossOtherGates) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, H);
-    qc.emplace_back<StandardOperation>(nqubits, 1, Z);
-    qc.emplace_back<StandardOperation>(nqubits, 0, Y);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
+    qc.emplace_back<StandardOperation>(nqubits, 1, qc::Z);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::Y);
     auto e = qc.buildFunctionality(dd);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
@@ -274,7 +273,7 @@ TEST_F(QFRFunctionality, FuseSingleQubitGatesAcrossOtherGates) {
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     EXPECT_EQ(qc.getNops(), 2);
-    EXPECT_TRUE(dd::Package::equals(e, f));
+    EXPECT_EQ(e, f);
 }
 
 TEST_F(QFRFunctionality, StripIdleAndDump) {
@@ -314,10 +313,10 @@ TEST_F(QFRFunctionality, StripIdleAndDump) {
 }
 
 TEST_F(QFRFunctionality, CollapseCompoundOperationToStandard) {
-    unsigned short     nqubits = 1;
+    QubitCount nqubits = 1;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
-    qc.emplace_back<StandardOperation>(nqubits, 0, I);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::I);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::singleQubitGateFusion(qc);
@@ -328,10 +327,10 @@ TEST_F(QFRFunctionality, CollapseCompoundOperationToStandard) {
 }
 
 TEST_F(QFRFunctionality, eliminateCompoundOperation) {
-    unsigned short     nqubits = 1;
+    QubitCount nqubits = 1;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, I);
-    qc.emplace_back<StandardOperation>(nqubits, 0, I);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::I);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::I);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::singleQubitGateFusion(qc);
@@ -342,7 +341,7 @@ TEST_F(QFRFunctionality, eliminateCompoundOperation) {
 }
 
 TEST_F(QFRFunctionality, eliminateInverseInCompoundOperation) {
-    unsigned short     nqubits = 1;
+    QubitCount nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, S);
     qc.emplace_back<StandardOperation>(nqubits, 0, Sdag);
@@ -356,7 +355,7 @@ TEST_F(QFRFunctionality, eliminateInverseInCompoundOperation) {
 }
 
 TEST_F(QFRFunctionality, unknownInverseInCompoundOperation) {
-    unsigned short     nqubits = 1;
+    QubitCount nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.emplace_back<StandardOperation>(nqubits, 0, Phase, 1.);
     qc.emplace_back<StandardOperation>(nqubits, 0, Phase, -1.);
@@ -369,10 +368,10 @@ TEST_F(QFRFunctionality, unknownInverseInCompoundOperation) {
 }
 
 TEST_F(QFRFunctionality, removeDiagonalSingleQubitBeforeMeasure) {
-    unsigned short     nqubits = 1;
+    QubitCount nqubits = 1;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, Z);
-    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0}, std::vector<unsigned short>{0});
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::Z);
+    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::removeDiagonalGatesBeforeMeasure(qc);
@@ -383,11 +382,11 @@ TEST_F(QFRFunctionality, removeDiagonalSingleQubitBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeDiagonalCompoundOpBeforeMeasure) {
-    unsigned short     nqubits = 1;
+    QubitCount nqubits = 1;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, Z);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::Z);
     qc.emplace_back<StandardOperation>(nqubits, 0, T);
-    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0}, std::vector<unsigned short>{0});
+    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::singleQubitGateFusion(qc);
@@ -399,10 +398,10 @@ TEST_F(QFRFunctionality, removeDiagonalCompoundOpBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeDiagonalTwoQubitGateBeforeMeasure) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, qc::Control(0), 1, Z);
-    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0, 1}, std::vector<unsigned short>{0, 1});
+    qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::Z);
+    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0, 1}, std::vector<std::size_t>{0, 1});
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::removeDiagonalGatesBeforeMeasure(qc);
@@ -413,11 +412,11 @@ TEST_F(QFRFunctionality, removeDiagonalTwoQubitGateBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, leaveGateBeforeMeasure) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, qc::Control(0), 1, Z);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
-    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0, 1}, std::vector<unsigned short>{0, 1});
+    qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::Z);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
+    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0, 1}, std::vector<std::size_t>{0, 1});
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::removeDiagonalGatesBeforeMeasure(qc);
@@ -427,19 +426,19 @@ TEST_F(QFRFunctionality, leaveGateBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeComplexGateBeforeMeasure) {
-    unsigned short     nqubits = 4;
+    QubitCount nqubits = 4;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, qc::Control(0), 1, Z);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
-    qc.emplace_back<StandardOperation>(nqubits, qc::Control(1), 2, Z);
-    qc.emplace_back<StandardOperation>(nqubits, qc::Control(0), 1, Z);
-    qc.emplace_back<StandardOperation>(nqubits, 0, Z);
-    qc.emplace_back<StandardOperation>(nqubits, qc::Control(1), 2, Z);
-    qc.emplace_back<StandardOperation>(nqubits, 3, X);
-    qc.emplace_back<StandardOperation>(nqubits, 3, T);
-    qc.emplace_back<StandardOperation>(nqubits, std::vector<qc::Control>{qc::Control(0), qc::Control(1), qc::Control(2)}, 3, Z);
+    qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::Z);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 1_pc, 2, qc::Z);
+    qc.emplace_back<StandardOperation>(nqubits, 0_pc, 1, qc::Z);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::Z);
+    qc.emplace_back<StandardOperation>(nqubits, 1_pc, 2, qc::Z);
+    qc.emplace_back<StandardOperation>(nqubits, 3, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 3, qc::T);
+    qc.emplace_back<StandardOperation>(nqubits, dd::Controls{0_pc, 1_pc, 2_pc}, 3, qc::Z);
 
-    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0, 1, 2, 3}, std::vector<unsigned short>{0, 1, 2, 3});
+    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0, 1, 2, 3}, std::vector<std::size_t>{0, 1, 2, 3});
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::removeDiagonalGatesBeforeMeasure(qc);
@@ -449,11 +448,11 @@ TEST_F(QFRFunctionality, removeComplexGateBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeSimpleCompoundOpBeforeMeasure) {
-    unsigned short     nqubits = 1;
+    QubitCount nqubits = 1;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
-    qc.emplace_back<StandardOperation>(nqubits, 0, T);
-    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0}, std::vector<unsigned short>{0});
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::T);
+    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::singleQubitGateFusion(qc);
@@ -464,12 +463,12 @@ TEST_F(QFRFunctionality, removeSimpleCompoundOpBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removePartOfCompoundOpBeforeMeasure) {
-    unsigned short     nqubits = 1;
+    QubitCount nqubits = 1;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, T);
-    qc.emplace_back<StandardOperation>(nqubits, 0, X);
-    qc.emplace_back<StandardOperation>(nqubits, 0, T);
-    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0}, std::vector<unsigned short>{0});
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::T);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::X);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::T);
+    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::singleQubitGateFusion(qc);
@@ -480,9 +479,9 @@ TEST_F(QFRFunctionality, removePartOfCompoundOpBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, decomposeSWAPsUndirectedArchitecture) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, std::vector<qc::Control>{}, 0, 1, SWAP);
+    qc.emplace_back<StandardOperation>(nqubits, Controls{}, 0, 1, SWAP);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::decomposeSWAP(qc, false);
@@ -491,29 +490,29 @@ TEST_F(QFRFunctionality, decomposeSWAPsUndirectedArchitecture) {
     auto it = qc.begin();
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), X);
-        EXPECT_EQ(op->getControls().at(0).qubit, 0);
+        EXPECT_EQ(op->getType(), qc::X);
+        EXPECT_EQ(op->getControls().begin()->qubit, 0);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), X);
-        EXPECT_EQ(op->getControls().at(0).qubit, 1);
+        EXPECT_EQ(op->getType(), qc::X);
+        EXPECT_EQ(op->getControls().begin()->qubit, 1);
         EXPECT_EQ(op->getTargets().at(0), 0);
     });
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), X);
-        EXPECT_EQ(op->getControls().at(0).qubit, 0);
+        EXPECT_EQ(op->getType(), qc::X);
+        EXPECT_EQ(op->getControls().begin()->qubit, 0);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
 }
 TEST_F(QFRFunctionality, decomposeSWAPsDirectedArchitecture) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, std::vector<qc::Control>{}, 0, 1, SWAP);
+    qc.emplace_back<StandardOperation>(nqubits, Controls{}, 0, 1, SWAP);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::decomposeSWAP(qc, true);
@@ -522,58 +521,58 @@ TEST_F(QFRFunctionality, decomposeSWAPsDirectedArchitecture) {
     auto it = qc.begin();
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), X);
-        EXPECT_EQ(op->getControls().at(0).qubit, 0);
+        EXPECT_EQ(op->getType(), qc::X);
+        EXPECT_EQ(op->getControls().begin()->qubit, 0);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), H);
+        EXPECT_EQ(op->getType(), qc::H);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), H);
+        EXPECT_EQ(op->getType(), qc::H);
         EXPECT_EQ(op->getTargets().at(0), 0);
     });
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), X);
-        EXPECT_EQ(op->getControls().at(0).qubit, 0);
+        EXPECT_EQ(op->getType(), qc::X);
+        EXPECT_EQ(op->getControls().begin()->qubit, 0);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), H);
+        EXPECT_EQ(op->getType(), qc::H);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), H);
+        EXPECT_EQ(op->getType(), qc::H);
         EXPECT_EQ(op->getTargets().at(0), 0);
     });
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), X);
-        EXPECT_EQ(op->getControls().at(0).qubit, 0);
+        EXPECT_EQ(op->getType(), qc::X);
+        EXPECT_EQ(op->getControls().begin()->qubit, 0);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
 }
 
 TEST_F(QFRFunctionality, decomposeSWAPsCompound) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<qc::StandardOperation>(nqubits, 0, qc::X); //We need something to replace with compound
     auto gate = std::make_unique<qc::CompoundOperation>(nqubits);
-    gate->emplace_back<qc::StandardOperation>(nqubits, std::vector<qc::Control>{}, 0, 1, qc::SWAP);
-    gate->emplace_back<qc::StandardOperation>(nqubits, std::vector<qc::Control>{}, 0, 1, qc::SWAP);
-    gate->emplace_back<qc::StandardOperation>(nqubits, std::vector<qc::Control>{}, 0, 1, qc::SWAP);
+    gate->emplace_back<qc::StandardOperation>(nqubits, Controls{}, 0, 1, qc::SWAP);
+    gate->emplace_back<qc::StandardOperation>(nqubits, Controls{}, 0, 1, qc::SWAP);
+    gate->emplace_back<qc::StandardOperation>(nqubits, Controls{}, 0, 1, qc::SWAP);
     (*qc.begin()) = std::move(gate);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
@@ -586,13 +585,13 @@ TEST_F(QFRFunctionality, decomposeSWAPsCompound) {
     EXPECT_EQ(dynamic_cast<qc::CompoundOperation*>(it->get())->size(), 9);
 }
 TEST_F(QFRFunctionality, decomposeSWAPsCompoundDirected) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<qc::StandardOperation>(nqubits, 0, qc::X); //We need something to replace with compound
     auto gate = std::make_unique<qc::CompoundOperation>(nqubits);
-    gate->emplace_back<qc::StandardOperation>(nqubits, std::vector<qc::Control>{}, 0, 1, qc::SWAP);
-    gate->emplace_back<qc::StandardOperation>(nqubits, std::vector<qc::Control>{}, 0, 1, qc::SWAP);
-    gate->emplace_back<qc::StandardOperation>(nqubits, std::vector<qc::Control>{}, 0, 1, qc::SWAP);
+    gate->emplace_back<qc::StandardOperation>(nqubits, Controls{}, 0, 1, qc::SWAP);
+    gate->emplace_back<qc::StandardOperation>(nqubits, Controls{}, 0, 1, qc::SWAP);
+    gate->emplace_back<qc::StandardOperation>(nqubits, Controls{}, 0, 1, qc::SWAP);
     (*qc.begin()) = std::move(gate);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
@@ -606,13 +605,13 @@ TEST_F(QFRFunctionality, decomposeSWAPsCompoundDirected) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurements) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, H);
-    qc.emplace_back<StandardOperation>(nqubits, 1, H);
-    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0}, std::vector<unsigned short>{0});
-    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{1}, std::vector<unsigned short>{1});
-    qc.emplace_back<StandardOperation>(nqubits, 1, H);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
+    qc.emplace_back<StandardOperation>(nqubits, 1, qc::H);
+    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
+    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{1}, std::vector<std::size_t>{1});
+    qc.emplace_back<StandardOperation>(nqubits, 1, qc::H);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::removeFinalMeasurements(qc);
@@ -628,18 +627,18 @@ TEST_F(QFRFunctionality, removeFinalMeasurements) {
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), H);
+        EXPECT_EQ(op->getType(), qc::H);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsTwoQubitMeasurement) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
-    qc.emplace_back<StandardOperation>(nqubits, 0, H);
-    qc.emplace_back<StandardOperation>(nqubits, 1, H);
-    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0, 1}, std::vector<unsigned short>{0, 1});
-    qc.emplace_back<StandardOperation>(nqubits, 1, H);
+    qc.emplace_back<StandardOperation>(nqubits, 0, qc::H);
+    qc.emplace_back<StandardOperation>(nqubits, 1, qc::H);
+    qc.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0, 1}, std::vector<std::size_t>{0, 1});
+    qc.emplace_back<StandardOperation>(nqubits, 1, qc::H);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::removeFinalMeasurements(qc);
@@ -655,21 +654,21 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsTwoQubitMeasurement) {
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), H);
+        EXPECT_EQ(op->getType(), qc::H);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsCompound) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<qc::StandardOperation>(nqubits, 0, qc::X); //We need something to replace with compound
     auto gate = std::make_unique<qc::CompoundOperation>(nqubits);
-    gate->emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0}, std::vector<unsigned short>{0});
-    gate->emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{1}, std::vector<unsigned short>{1});
-    gate->emplace_back<StandardOperation>(nqubits, 1, H);
+    gate->emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
+    gate->emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{1}, std::vector<std::size_t>{1});
+    gate->emplace_back<StandardOperation>(nqubits, 1, qc::H);
     (*qc.begin()) = std::move(gate);
-    qc.emplace_back<StandardOperation>(nqubits, 1, H);
+    qc.emplace_back<StandardOperation>(nqubits, 1, qc::H);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::removeFinalMeasurements(qc);
@@ -682,20 +681,20 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsCompound) {
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), H);
+        EXPECT_EQ(op->getType(), qc::H);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundDegraded) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<qc::StandardOperation>(nqubits, 0, qc::X); //We need something to replace with compound
     auto gate = std::make_unique<qc::CompoundOperation>(nqubits);
-    gate->emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0}, std::vector<unsigned short>{0});
-    gate->emplace_back<StandardOperation>(nqubits, 1, H);
+    gate->emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
+    gate->emplace_back<StandardOperation>(nqubits, 1, qc::H);
     (*qc.begin()) = std::move(gate);
-    qc.emplace_back<StandardOperation>(nqubits, 1, H);
+    qc.emplace_back<StandardOperation>(nqubits, 1, qc::H);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::removeFinalMeasurements(qc);
@@ -704,25 +703,25 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundDegraded) {
     auto it = qc.begin();
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), H);
+        EXPECT_EQ(op->getType(), qc::H);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
     ++it;
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), H);
+        EXPECT_EQ(op->getType(), qc::H);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundEmpty) {
-    unsigned short     nqubits = 2;
+    QubitCount nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.emplace_back<qc::StandardOperation>(nqubits, 0, qc::X); //We need something to replace with compound
     auto gate = std::make_unique<qc::CompoundOperation>(nqubits);
-    gate->emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0}, std::vector<unsigned short>{0});
+    gate->emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
     (*qc.begin()) = std::move(gate);
-    qc.emplace_back<StandardOperation>(nqubits, 1, H);
+    qc.emplace_back<StandardOperation>(nqubits, 1, qc::H);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::removeFinalMeasurements(qc);
@@ -731,7 +730,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundEmpty) {
     auto it = qc.begin();
     ASSERT_NO_THROW({
         auto op = dynamic_cast<StandardOperation*>(it->get());
-        EXPECT_EQ(op->getType(), H);
+        EXPECT_EQ(op->getType(), qc::H);
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
 }


### PR DESCRIPTION
This PR refactors the QFR library to work with the new DD Package version released recently. As a consequence the performance of practically all DD related routines should be improved.

✨ separation of matrix and vector DDs
✨ dynamic qubit numbers for DD package
✨ introduce `Definitions` file containing the most used definitions/constants
🔥 removed `line` parameter
🎨 `unsigned short` -> `dd::Qubit` for qubits, `unsigned short` to `dd::QubitCount` for numbers of qubits, `std::size_t` mostly everywhere else for consistency
♻️ controls are no longer a vector but a set
♻️ Measurement operations now hold separate vectors for qubits and classics
🐛 fix bug where permutation was not correctly accounted for in recursive functionality construction
🐛 fix bug where reference counting was not done correctly when recursively building the functionality of Grover's algorithm
🐛 fix reference counting bug in `reduceAncillary` and `reduceGarbage` methods
🔥 removed non-implemented `dumpReal`
🔥 remove DEBUG_MODE_QC
♻️ moved DD generation routines (e.g. for SWAP) to DD Package
🐛 Enable LTO for all targets
🐧 disable LTO in case clang is used under linux
✅ allow some up and down in project coverage