### PR TITLE
Fix bugs in optimization passes

### DIFF
--- a/include/CircuitOptimizer.hpp
+++ b/include/CircuitOptimizer.hpp
@@ -38,8 +38,6 @@ namespace qc {
 
         static bool removeDiagonalGate(DAG& dag, DAGIterators& dagIterators, dd::Qubit idx, DAGIterator& it, qc::Operation* op);
 
-        static void removeMarkedMeasurements(QuantumComputation& qc);
-
         static void removeFinalMeasurements(QuantumComputation& qc);
 
         static void removeFinalMeasurementsRecursive(DAG& dag, DAGIterators& DAGIterators, dd::Qubit idx, const DAGIterator& until);

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -39,9 +39,6 @@ namespace qc {
     }
 
     void CircuitOptimizer::swapReconstruction(QuantumComputation& qc) {
-        // print incoming circuit
-        //qc.print(std::cout );
-        //std::cout << std::endl;
         dd::Qubit highest_physical_qubit = 0;
         for (const auto& q: qc.initialLayout) {
             if (q.first > highest_physical_qubit)
@@ -148,9 +145,6 @@ namespace qc {
         }
 
         removeIdentities(qc);
-
-        // print resulting circuit
-        //qc.print(std::cout );
     }
 
     DAG CircuitOptimizer::constructDAG(QuantumComputation& qc) {
@@ -172,12 +166,7 @@ namespace qc {
                         }
                     }
                     continue;
-                } else if (it->getType() == qc::Measure) {
-                    for (const auto& t: it->getTargets()) {
-                        dag.at(t).push_front(&it);
-                    }
-                    continue;
-                } else if (it->getType() == qc::Barrier || it->getType() == qc::Reset) {
+                } else if (it->isNonUnitaryOperation()) {
                     for (const auto& b: it->getTargets()) {
                         dag.at(b).push_front(&it);
                     }

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -10,12 +10,8 @@ namespace qc {
         // delete the identities from circuit
         auto it = qc.ops.begin();
         while (it != qc.ops.end()) {
-            if ((*it)->isStandardOperation()) {
-                if ((*it)->getType() == I) {
-                    it = qc.ops.erase(it);
-                } else {
-                    ++it;
-                }
+            if ((*it)->getType() == I) {
+                it = qc.ops.erase(it);
             } else if ((*it)->isCompoundOperation()) {
                 auto compOp = dynamic_cast<qc::CompoundOperation*>((*it).get());
                 auto cit    = compOp->cbegin();
@@ -526,42 +522,6 @@ namespace qc {
         removeIdentities(qc);
     }
 
-    void CircuitOptimizer::removeMarkedMeasurements(QuantumComputation& qc) {
-        // delete the identities from circuit
-        auto it = qc.ops.begin();
-        while (it != qc.ops.end()) {
-            if (!(*it)->isCompoundOperation()) {
-                if ((*it)->getType() == I) {
-                    it = qc.ops.erase(it);
-                } else {
-                    ++it;
-                }
-            } else if ((*it)->isCompoundOperation()) {
-                auto compOp = dynamic_cast<qc::CompoundOperation*>((*it).get());
-                auto cit    = compOp->cbegin();
-                while (cit != compOp->cend()) {
-                    auto cop = cit->get();
-                    if (cop->getType() == qc::I) {
-                        cit = compOp->erase(cit);
-                    } else {
-                        ++cit;
-                    }
-                }
-                if (compOp->empty()) {
-                    it = qc.ops.erase(it);
-                } else {
-                    if (compOp->size() == 1) {
-                        // CompoundOperation has degraded to single Operation
-                        (*it) = std::move(*(compOp->begin()));
-                    }
-                    ++it;
-                }
-            } else {
-                ++it;
-            }
-        }
-    }
-
     bool CircuitOptimizer::removeFinalMeasurement(DAG& dag, DAGIterators& dagIterators, dd::Qubit idx, DAGIterator& it, qc::Operation* op) {
         if (op->getNtargets() != 0) {
             // need to check all targets
@@ -669,7 +629,7 @@ namespace qc {
 
         removeFinalMeasurementsRecursive(dag, dagIterators, 0, dag.at(0).end());
 
-        removeMarkedMeasurements(qc);
+        removeIdentities(qc);
     }
 
     void CircuitOptimizer::decomposeSWAP(QuantumComputation& qc, bool isDirectedArchitecture) {

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -421,7 +421,7 @@ namespace qc {
                 }
             }
             auto op = (*it)->get();
-            if (op->getType() == Barrier) {
+            if (op->getType() == Barrier || op->getType() == Snapshot || op->getType() == ShowProbabilities) {
                 // either ignore barrier statement here or end for this qubit;
                 ++it;
             } else if (op->isStandardOperation()) {

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -58,12 +58,7 @@ namespace qc {
                         }
                     }
                     continue;
-                } else if (it->getType() == qc::Measure) {
-                    for (const auto& c: it->getControls()) {
-                        dag.at(c.qubit).push_front(&it);
-                    }
-                    continue;
-                } else if (it->getType() == qc::Barrier || it->getType() == qc::Reset) {
+                } else if (it->isNonUnitaryOperation()) {
                     for (const auto& b: it->getTargets()) {
                         dag.at(b).push_front(&it);
                     }
@@ -231,12 +226,7 @@ namespace qc {
                         }
                     }
                     continue;
-                } else if (it->getType() == qc::Measure) {
-                    for (const auto& c: it->getControls()) {
-                        dag.at(c.qubit).push_front(&it);
-                    }
-                    continue;
-                } else if (it->getType() == qc::Barrier || it->getType() == qc::Reset) {
+                } else if (it->isNonUnitaryOperation()) {
                     for (const auto& b: it->getTargets()) {
                         dag.at(b).push_front(&it);
                     }

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -734,3 +734,18 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundEmpty) {
         EXPECT_EQ(op->getTargets().at(0), 1);
     });
 }
+
+TEST_F(QFRFunctionality, removeFinalMeasurementsWithOperationsInFront) {
+    auto              circ = "OPENQASM 2.0;include \"qelib1.inc\";qreg q[3];qreg r[3];h q;cx q, r;creg c[3];creg d[3];barrier q;measure q->c;measure r->d;\n";
+    std::stringstream ss{};
+    ss << circ;
+    QuantumComputation qc{};
+    qc.import(ss, qc::OpenQASM);
+    std::cout << "-----------------------------" << std::endl;
+    qc.print(std::cout);
+    CircuitOptimizer::removeFinalMeasurements(qc);
+    std::cout << "-----------------------------" << std::endl;
+    qc.print(std::cout);
+    ASSERT_EQ(qc.getNops(), 3);
+    ASSERT_EQ(qc.getNindividualOps(), 7);
+}


### PR DESCRIPTION
This PR addresses some bugs in the QFR optimization passes. In particular, the `removeFinalMeasurements` pass was not working as expected in some circumstances. Furthermore, some of the optimisation passes were not treating measurements and other non-unitary operations correctly.