### PR TITLE
Fix iSWAP & Peres OpenQASM export

### DIFF
--- a/src/operations/StandardOperation.cpp
+++ b/src/operations/StandardOperation.cpp
@@ -401,7 +401,7 @@ namespace qc {
                 of << op.str() << "cz";
                 for (const auto& c: controls)
                     of << " " << qreg[c.qubit].second << ",";
-                of << qreg[targets[0]].second << ", " << qreg[targets[1]].second << ";" << std::endl;
+                of << " " << qreg[targets[0]].second << ", " << qreg[targets[1]].second << ";" << std::endl;
 
                 for (const auto& c: controls) {
                     if (c.type == dd::Control::Type::neg)
@@ -412,23 +412,23 @@ namespace qc {
                 of << op.str() << "cx";
                 for (const auto& c: controls)
                     of << " " << qreg[c.qubit].second << ",";
-                of << qreg[targets[1]].second << ", " << qreg[targets[0]].second << ";" << std::endl;
+                of << " " << qreg[targets[1]].second << ", " << qreg[targets[0]].second << ";" << std::endl;
 
                 of << op.str() << "x";
                 for (const auto& c: controls)
                     of << " " << qreg[c.qubit].second << ",";
-                of << qreg[targets[1]].second << ";" << std::endl;
+                of << " " << qreg[targets[1]].second << ";" << std::endl;
                 return;
             case Peresdag:
                 of << op.str() << "x";
                 for (const auto& c: controls)
                     of << " " << qreg[c.qubit].second << ",";
-                of << qreg[targets[1]].second << ";" << std::endl;
+                of << " " << qreg[targets[1]].second << ";" << std::endl;
 
                 of << op.str() << "cx";
                 for (const auto& c: controls)
                     of << " " << qreg[c.qubit].second << ",";
-                of << qreg[targets[1]].second << ", " << qreg[targets[0]].second << ";" << std::endl;
+                of << " " << qreg[targets[1]].second << ", " << qreg[targets[0]].second << ";" << std::endl;
                 return;
             case Teleportation:
                 if (!controls.empty() || targets.size() != 3) {

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -276,3 +276,33 @@ TEST_F(IO, changePermutation) {
     EXPECT_TRUE(func.p->e[2].p->e[0].w.approximatelyOne());
     EXPECT_TRUE(func.p->e[3].p->e[2].w.approximatelyOne());
 }
+
+TEST_F(IO, iSWAP_dump_is_valid) {
+    qc->addQubitRegister(2);
+    qc->iswap(0, 1);
+    std::cout << *qc << std::endl;
+    std::stringstream ss{};
+    qc->dumpOpenQASM(ss);
+    EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM););
+    std::cout << *qc << std::endl;
+}
+
+TEST_F(IO, Peres_dump_is_valid) {
+    qc->addQubitRegister(2);
+    qc->peres(0, 1);
+    std::cout << *qc << std::endl;
+    std::stringstream ss{};
+    qc->dumpOpenQASM(ss);
+    EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM););
+    std::cout << *qc << std::endl;
+}
+
+TEST_F(IO, Peresdag_dump_is_valid) {
+    qc->addQubitRegister(2);
+    qc->peresdag(0, 1);
+    std::cout << *qc << std::endl;
+    std::stringstream ss{};
+    qc->dumpOpenQASM(ss);
+    EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM););
+    std::cout << *qc << std::endl;
+}


### PR DESCRIPTION
The `iSWAP`, `Peres` and `Peresdag` gates were exported with invalid OpenQASM caused by missing spaces when there are no control qubits.

A dump of an `iSWAP(0, 1)` gate previously looked as follows:

```qasm
swap q[0], q[1];
s q[0];
s q[1];
czq[0], q[1];
```