### PR TITLE
Extract circuit name from Qiskit `QuantumCircuit` object

### DIFF
--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -229,6 +229,8 @@ namespace qc {
         [[nodiscard]] const ClassicalRegisterMap& getCregs() const { return cregs; }
         [[nodiscard]] const QuantumRegisterMap&   getANCregs() const { return ancregs; }
 
+        void setName(const std::string& n) { name = n; }
+
         // initialLayout[physical_qubit] = logical_qubit
         Permutation initialLayout{};
         Permutation outputPermutation{};

--- a/jkq/qfr/qiskit/QuantumCircuit.hpp
+++ b/jkq/qfr/qiskit/QuantumCircuit.hpp
@@ -25,6 +25,10 @@ namespace qc::qiskit {
                 throw QFRException("[import] Python object needs to be a Qiskit QuantumCircuit");
             }
 
+            if (!circ.attr("name").is_none()) {
+                qc.setName(circ.attr("name").cast<std::string>());
+            }
+
             // import initial layout in case it is available
             if (!circ.attr("_layout").is_none()) {
                 importInitialLayout(qc, circ);


### PR DESCRIPTION
Previously, importing a Qiskit `QuantumCircuit` into the QFR would just result in a blank name. 
This PR adds the functionality to correctly extract and set the name.