### PR TITLE
Test for compiler flag -march=native

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,12 @@ else()
 	endif ()
 	if (NOT DEPLOY)
 		# only include machine-specific optimizations when building for the host machine
-		target_compile_options(${PROJECT_NAME} PUBLIC -mtune=native -march=native)
+		target_compile_options(${PROJECT_NAME} PUBLIC -mtune=native)
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag(-march=native HAS_MARCH_NATIVE)
+        if (HAS_MARCH_NATIVE)
+            target_compile_options(${PROJECT_NAME} PUBLIC -march=native)
+        endif()
 	endif ()
 endif()
 


### PR DESCRIPTION
Added a test in the CMakeLists.txt before adding the -march=native flag

The latest clang (clang-1300.0.29.30) on Apple M1 does not support it (yet?)

Depends on https://github.com/iic-jku/dd_package/pull/30 & submodule reference needs to be updated